### PR TITLE
Fix relay toggle when button action is set to none

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_relays.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_relays.yaml
@@ -207,24 +207,36 @@ script:
               if (sl_button_1_action->state != "${BUTTON_ACTION_NONE_TEXT}") {
                 ESP_LOGV("core_hw_relays", "Toggle relay 1: (%s)", sl_button_1_action->state.c_str());
                 sw_relay_1->toggle();
+              } else {
+                ESP_LOGV("core_hw_relays", "Ignoring toggle for relay 1: action is '%s'",
+                          sl_button_1_action->state.c_str());
               }
               break;
             case ${BUTTON_2_ID}:
               if (sl_button_2_action->state != "${BUTTON_ACTION_NONE_TEXT}") {
                 ESP_LOGV("core_hw_relays", "Toggle relay 2: (%s)", sl_button_2_action->state.c_str());
                 sw_relay_2->toggle();
+              } else {
+                ESP_LOGV("core_hw_relays", "Ignoring toggle for relay 2: action is '%s'",
+                          sl_button_2_action->state.c_str());
               }
               break;
             case ${BUTTON_3_ID}:
               if (sl_button_3_action->state != "${BUTTON_ACTION_NONE_TEXT}") {
                 ESP_LOGV("core_hw_relays", "Toggle relay 3: (%s)", sl_button_3_action->state.c_str());
                 sw_relay_3->toggle();
+              } else {
+                ESP_LOGV("core_hw_relays", "Ignoring toggle for relay 3: action is '%s'",
+                          sl_button_3_action->state.c_str());
               }
               break;
             case ${BUTTON_4_ID}:
               if (sl_button_4_action->state != "${BUTTON_ACTION_NONE_TEXT}") {
                 ESP_LOGV("core_hw_relays", "Toggle relay 4: (%s)", sl_button_4_action->state.c_str());
                 sw_relay_4->toggle();
+              } else {
+                ESP_LOGV("core_hw_relays", "Ignoring toggle for relay 4: action is '%s'",
+                          sl_button_4_action->state.c_str());
               }
               break;
           }

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_relays.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_relays.yaml
@@ -189,22 +189,43 @@ script:
           }
 
           // Toggle relay if corresponding button action is enabled
+          ESP_LOGVV("core_hw_relays", "Toggle relays: (${BUTTON_ACTION_NONE_TEXT})");
+          ESP_LOGVV("core_hw_relays", "  Relay 1: %s (%s)",
+                    YESNO(sl_button_1_action->state != "${BUTTON_ACTION_NONE_TEXT}"),
+                    sl_button_1_action->state.c_str());
+          ESP_LOGVV("core_hw_relays", "  Relay 2: %s (%s)",
+                    YESNO(sl_button_2_action->state != "${BUTTON_ACTION_NONE_TEXT}"),
+                    sl_button_2_action->state.c_str());
+          ESP_LOGVV("core_hw_relays", "  Relay 3: %s (%s)",
+                    YESNO(sl_button_3_action->state != "${BUTTON_ACTION_NONE_TEXT}"),
+                    sl_button_3_action->state.c_str());
+          ESP_LOGVV("core_hw_relays", "  Relay 4: %s (%s)",
+                    YESNO(sl_button_4_action->state != "${BUTTON_ACTION_NONE_TEXT}"),
+                    sl_button_4_action->state.c_str());
           switch (button) {
             case ${BUTTON_1_ID}:
-              if (sl_button_1_action->state != "${RELAY_MODE_TEXT_NOT_USED}")
+              if (sl_button_1_action->state != "${BUTTON_ACTION_NONE_TEXT}") {
+                ESP_LOGV("core_hw_relays", "Toggle relay 1: (%s)", sl_button_1_action->state.c_str());
                 sw_relay_1->toggle();
+              }
               break;
             case ${BUTTON_2_ID}:
-              if (sl_button_2_action->state != "${RELAY_MODE_TEXT_NOT_USED}")
+              if (sl_button_2_action->state != "${BUTTON_ACTION_NONE_TEXT}") {
+                ESP_LOGV("core_hw_relays", "Toggle relay 2: (%s)", sl_button_2_action->state.c_str());
                 sw_relay_2->toggle();
+              }
               break;
             case ${BUTTON_3_ID}:
-              if (sl_button_3_action->state != "${RELAY_MODE_TEXT_NOT_USED}")
+              if (sl_button_3_action->state != "${BUTTON_ACTION_NONE_TEXT}") {
+                ESP_LOGV("core_hw_relays", "Toggle relay 3: (%s)", sl_button_3_action->state.c_str());
                 sw_relay_3->toggle();
+              }
               break;
             case ${BUTTON_4_ID}:
-              if (sl_button_4_action->state != "${RELAY_MODE_TEXT_NOT_USED}")
+              if (sl_button_4_action->state != "${BUTTON_ACTION_NONE_TEXT}") {
+                ESP_LOGV("core_hw_relays", "Toggle relay 4: (%s)", sl_button_4_action->state.c_str());
                 sw_relay_4->toggle();
+              }
               break;
           }
 

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_touch.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_touch.yaml
@@ -311,9 +311,9 @@ script:
   - id: touch_on_release
     mode: restart
     then:
-      # Extended by:
-      #   - HW Buttons
-      #   - HW Vibration
+    # Extended by:
+    #   - HW Buttons
+    #   - HW Vibration
 
   - id: touch_swipe_left
     mode: restart


### PR DESCRIPTION
Solves #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logging for relay control actions.
	- Added new binary sensor events for various touch panel actions, including clicks, double clicks, long presses, and swipe gestures.
	- Introduced new scripts for touch panel initialization and state management.

- **Bug Fixes**
	- Improved error logging for invalid touch positions and swipe directions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->