### PR TITLE
Restore light state on boot

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
@@ -44,6 +44,7 @@ light:
     # method: esp32_rmt
     num_leds: 32
     pin: GPIO13
+    restore_mode: RESTORE_DEFAULT_OFF
 
   # Those lights are available based on the model selections
   - &light_partition_with_effects
@@ -52,6 +53,7 @@ light:
     platform: partition
     default_transition_length: ${default_transition_length}
     internal: true
+    restore_mode: RESTORE_DEFAULT_OFF
     effects:
       - addressable_rainbow:
           name: "Rainbow"
@@ -184,6 +186,8 @@ light:
     platform: partition
     disabled_by_default: true
     default_transition_length: ${default_transition_length}
+    restore_mode: RESTORE_DEFAULT_OFF
+
     segments:
       - id: light_full
         from: 0
@@ -417,6 +421,7 @@ light:
     platform: partition
     internal: true
     default_transition_length: ${default_transition_length}
+    restore_mode: RESTORE_DEFAULT_OFF
     segments:
       - id: light_full
         from: 9

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
@@ -25,6 +25,11 @@ substitutions:
   LIGHT_TRANSITION_TURN_OFF: '0'  # Transition time in msec
   LIGHT_BRIGHTNESS_TURN_ON: '0'   # Brightness (1 to 100%, 0 to not set it)
 
+  LIGHT_FULL_RESTORE_MODE: RESTORE_DEFAULT_OFF
+  LIGHT_SIDES_RESTORE_MODE: RESTORE_DEFAULT_OFF
+  LIGHT_INDIVIDUAL_RESTORE_MODE: RESTORE_DEFAULT_OFF
+  LIGHT_RELAYS_RESTORE_MODE: RESTORE_DEFAULT_OFF
+
 globals:
   - id: gb_lights_1
     type: std::vector<light::LightState*>
@@ -44,7 +49,7 @@ light:
     # method: esp32_rmt
     num_leds: 32
     pin: GPIO13
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: ${LIGHT_FULL_RESTORE_MODE}
 
   # Those lights are available based on the model selections
   - &light_partition_with_effects
@@ -53,7 +58,7 @@ light:
     platform: partition
     default_transition_length: ${default_transition_length}
     internal: true
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: ${LIGHT_SIDES_RESTORE_MODE}
     effects:
       - addressable_rainbow:
           name: "Rainbow"
@@ -186,8 +191,7 @@ light:
     platform: partition
     disabled_by_default: true
     default_transition_length: ${default_transition_length}
-    restore_mode: RESTORE_DEFAULT_OFF
-
+    restore_mode: ${LIGHT_FULL_RESTORE_MODE}
     segments:
       - id: light_full
         from: 0
@@ -421,7 +425,7 @@ light:
     platform: partition
     internal: true
     default_transition_length: ${default_transition_length}
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: ${LIGHT_RELAYS_RESTORE_MODE}
     segments:
       - id: light_full
         from: 9

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
@@ -191,7 +191,7 @@ light:
     platform: partition
     disabled_by_default: true
     default_transition_length: ${default_transition_length}
-    restore_mode: ${LIGHT_FULL_RESTORE_MODE}
+    restore_mode: ${LIGHT_INDIVIDUAL_RESTORE_MODE}
     segments:
       - id: light_full
         from: 0

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_relays.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_relays.yaml
@@ -15,6 +15,7 @@ substitutions:
   RELAY_MODE_TEXT_SWITCH: "Switch"
   RELAY_MODE_TEXT_LIGHT: "Light"
   RELAY_MODE_TEXT_NOT_USED: "Not in use"
+  RELAY_RESTORE_MODE: RESTORE_DEFAULT_OFF
 
 globals:
   - id: boot_initialization_relays
@@ -29,7 +30,7 @@ light:
     output: output_relay_1
     platform: binary
     internal: true
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: ${RELAY_RESTORE_MODE}
     on_turn_on:
       then:
         - if:
@@ -350,7 +351,7 @@ switch:
     name: Relay 1
     output: output_relay_1
     platform: output
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: ${RELAY_RESTORE_MODE}
     internal: true
     on_turn_on:
       then:
@@ -373,7 +374,7 @@ switch:
     name: Relay 2
     output: output_relay_2
     platform: output
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: ${RELAY_RESTORE_MODE}
     internal: true
     on_turn_on:
       then:
@@ -396,7 +397,7 @@ switch:
     name: Relay 3
     output: output_relay_3
     platform: output
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: ${RELAY_RESTORE_MODE}
     internal: true
     on_turn_on:
       then:
@@ -419,7 +420,7 @@ switch:
     name: Relay 4
     output: output_relay_4
     platform: output
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: ${RELAY_RESTORE_MODE}
     internal: true
     on_turn_on:
       then:

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_relays.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_relays.yaml
@@ -29,6 +29,7 @@ light:
     output: output_relay_1
     platform: binary
     internal: true
+    restore_mode: RESTORE_DEFAULT_OFF
     on_turn_on:
       then:
         - if:


### PR DESCRIPTION
Trying to solve #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new `restore_mode` options for light entities, ensuring they default to an off state upon system restart.
	- Added a `RELAY_RESTORE_MODE` for relay entities, enhancing their initialization behavior.
	- Standardized power state behavior for individual LEDs and relay lights on startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->