### PR TITLE
Add speaker to BLE Proxy add-on

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_addon_ble_proxy.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_addon_ble_proxy.yaml
@@ -11,6 +11,25 @@
 ##### - For normal system use, modifications to this file are NOT required.                    #####
 ####################################################################################################
 ---
+substitutions:
+  tone_volume_change: "scale_up:d=32,o=5,b=100:c,c#,d#,e,f#,g#,a#,b"  # Use to "none" for no sound
+
+api:
+  actions:
+    - action: rtttl_play
+      variables:
+        # The RTTTL string for the melody to be played.
+        # It should follow the RTTTL format, including the melody's name,
+        # default settings, and a sequence of notes.
+        tone: string
+      then:
+        - lambda: |-
+            rtttl_speaker->stop();
+            if (rtttl_speaker_gain->state > 0) {
+              ESP_LOGI("api", "Play tone: '%s'", tone.c_str());
+              rtttl_speaker->play(tone.c_str());
+            }
+
 bluetooth_proxy:
 
 esp32:
@@ -33,17 +52,54 @@ esphome:
     build_flags:
       - -D TX_ULTIMATE_EASY_ADDON_BLE_PROXY
 
-i2s_audio: !remove
-
 light:
   - id: !extend light_full
     platform: esp32_rmt_led_strip
     rgb_order: GRB
-    rmt_channel: 0
+    rmt_channel: 1
     chipset: ws2812
     type: !remove
     variant: !remove
     max_refresh_rate: 33ms
+    use_psram: true
 
 media_player: !remove
+
+number:
+  - id: rtttl_speaker_gain
+    name: Sound - Volume
+    platform: template
+    max_value: 100
+    min_value: 0
+    step: 1
+    initial_value: 100
+    unit_of_measurement: "%"
+    internal: false
+    disabled_by_default: true
+    entity_category: config
+    device_class: sound_pressure
+    restore_value: true
+    optimistic: true
+    set_action:
+      then:
+        - lambda: |-
+            rtttl_speaker->set_gain((100-(x/10.0f))/100.0f);
+            std::string tone_volume_change = "${tone_volume_change}";
+            // Play sound if tone_volume_change is not "none"
+            if (x > 0 and !tone_volume_change.empty() and tone_volume_change != "none")
+              rtttl_speaker->play(tone_volume_change);
+            rtttl_speaker->dump_config();
+
+rtttl:
+  - id: rtttl_speaker
+    speaker: mp_speaker
+
+speaker:
+  - id: mp_speaker
+    platform: i2s_audio
+    dac_type: external
+    i2s_dout_pin: GPIO15
+    i2s_audio_id: if_i2s_audio
+    i2s_comm_fmt: stand_msb
+    channel: mono
 ...

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_addon_ble_proxy.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_addon_ble_proxy.yaml
@@ -12,7 +12,9 @@
 ####################################################################################################
 ---
 substitutions:
-  tone_volume_change: "scale_up:d=32,o=5,b=100:c,c#,d#,e,f#,g#,a#,b"  # Use to "none" for no sound
+  # RTTTL format: name:d=duration,o=octave,b=tempo:notes
+  # d=32 (32nd note), o=5 (octave 5), b=100 (tempo 100)
+  tone_volume_change: "scale_up:d=32,o=5,b=100:c,c#,d#,e,f#,g#,a#,b"  # Use "none" to disable sound
 
 api:
   actions:

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core.yaml
@@ -85,6 +85,8 @@ ota:
   platform: esphome
 
 psram:
+  mode: octal
+  speed: 40MHz
 
 script:
   - id: api_send_ha_event_boot

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_speaker.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_speaker.yaml
@@ -19,11 +19,11 @@ i2s_audio:
 media_player:
   - id: mp_speaker
     name: Speaker
+    internal: false
     platform: i2s_audio
     i2s_dout_pin: GPIO15
     i2s_audio_id: if_i2s_audio
     i2s_comm_fmt: lsb
     dac_type: external
     mode: mono
-    internal: false
 ...

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_speaker.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_speaker.yaml
@@ -23,7 +23,7 @@ media_player:
     platform: i2s_audio
     i2s_dout_pin: GPIO15
     i2s_audio_id: if_i2s_audio
-    i2s_comm_fmt: lsb
+    i2s_comm_fmt: msb  # Experimental - It was 'lsb' until v2024.12.12
     dac_type: external
     mode: mono
 ...


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new variable `tone_volume_change` for sound playback control.
  - Added action `rtttl_play` to play tones based on speaker gain.
  - New number entity `rtttl_speaker_gain` for volume control.
  - Defined new RTTTL speaker entity `rtttl_speaker` and speaker entity `mp_speaker` with audio configurations.

- **Enhancements**
  - Updated PSRAM configuration with new mode and speed settings.
  - Clarified `mp_speaker` configuration by setting `internal` attribute to false.

- **Bug Fixes**
  - Removed the media player configuration to streamline functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->