### PR TITLE
Add ESPHome Version sensor

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core.yaml
@@ -167,8 +167,12 @@ select:
         - lambda: tx_ultimate->set_gang_count(static_cast<uint8_t>(i)+1);
 
 text_sensor:
+  - id: esphome_fw_version
+    platform: version
+    name: "ESPHome Version"
+
   - id: tx_fw_version
-    name: Firmware version
+    name: TX Ultimate Easy Firmware Version
     platform: template
     entity_category: diagnostic
     icon: mdi:tag-text-outline

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core.yaml
@@ -168,8 +168,10 @@ select:
 
 text_sensor:
   - id: esphome_fw_version
+    name: ESPHome Version
     platform: version
-    name: "ESPHome Version"
+    entity_category: diagnostic
+    internal: false
 
   - id: tx_fw_version
     name: TX Ultimate Easy Firmware Version


### PR DESCRIPTION
And renames the TX Firmware, which resolves #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new text sensor to display the ESPHome version.
  
- **Improvements**
  - Updated the name of the existing firmware version sensor for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->