### PR TITLE
Expose relay-indicator LEDs

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core.yaml
@@ -41,6 +41,15 @@ api:
     then:
       - script.execute: publish_device_info
 
+binary_sensor:
+  - id: bs_pending_restart
+    name: Pending Restart Status
+    internal: false
+    disabled_by_default: false
+    platform: template
+    entity_category: diagnostic
+    device_class: problem
+
 button:
   - id: bt_restart
     name: Restart
@@ -97,7 +106,7 @@ ota:
 
 psram:
   mode: octal
-  speed: 40MHz
+  speed: 80MHz
 
 script:
   - id: api_send_ha_event_boot
@@ -130,11 +139,24 @@ script:
       - script.execute:
           id: api_send_ha_event_boot
           type: start
+      - wait_until:
+          condition:
+            - lambda: return sl_tx_model_format->active_index().has_value();
+            - lambda: return sl_tx_model_gang->active_index().has_value();
+      - lambda: |-
+          id(is_us_model) = (sl_tx_model_format->state == "${TX_MODEL_FORMAT_US_TEXT}");
+          id(gang_count) = sl_tx_model_gang->active_index().value() + 1;
+          if (id(gang_count) < 1 || id(gang_count) > 4) {
+            ESP_LOGE("core_hw_leds", "Invalid number of gangs: %" PRIu8, id(gang_count));
+          }
 
   - id: boot_sequence
     mode: restart
     then:
       - script.execute: publish_device_info
+      - binary_sensor.template.publish:
+          id: bs_pending_restart
+          state: false
 
   - id: publish_device_info
     mode: restart
@@ -159,6 +181,9 @@ select:
     icon: mdi:tablet-cellphone
     on_value:
       then:
+        - binary_sensor.template.publish:
+            id: bs_pending_restart
+            state: true
         - lambda: |-
             id(is_us_model) = (x == "${TX_MODEL_FORMAT_US_TEXT}");
             ESP_LOGI("core", "New model selected: %s", id(is_us_model) ? "US" : "EU");
@@ -180,6 +205,9 @@ select:
     icon: mdi:dip-switch
     on_value:
       then:
+        - binary_sensor.template.publish:
+            id: bs_pending_restart
+            state: true
         - lambda: |-
             id(gang_count) = static_cast<uint8_t>(i) + 1;
             ESP_LOGI("core", "New model selected: %" PRIu8 "-%s", id(gang_count), id(gang_count) > 1 ? "Gangs" : "Gang");

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_buttons.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_buttons.yaml
@@ -86,28 +86,19 @@ script:
   - id: boot_initialize_buttons
     mode: restart
     then:
-      - wait_until:
-          condition:
-            - lambda: return sl_tx_model_gang->active_index().has_value();
       - lambda: |-
-          const uint8_t num_gangs = (sl_tx_model_gang->active_index().has_value()) ?
-                                    (sl_tx_model_gang->active_index().value() + 1) : 0;
-          if (num_gangs < 1 || num_gangs > 4) {
-            ESP_LOGE("core_hw_buttons", "Invalid number of gangs: %" PRIu8, num_gangs);
-            return;
-          }
           bs_button_1->publish_state(false);
-          bs_button_1->set_internal(num_gangs < 1);
-          sl_button_1_action->set_internal(num_gangs < 1);
+          bs_button_1->set_internal(id(gang_count) < 1);
+          sl_button_1_action->set_internal(id(gang_count) < 1);
           bs_button_2->publish_state(false);
-          bs_button_2->set_internal(num_gangs < 2);
-          sl_button_2_action->set_internal(num_gangs < 2);
+          bs_button_2->set_internal(id(gang_count) < 2);
+          sl_button_2_action->set_internal(id(gang_count) < 2);
           bs_button_3->publish_state(false);
-          bs_button_3->set_internal(num_gangs < 3);
-          sl_button_3_action->set_internal(num_gangs < 3);
+          bs_button_3->set_internal(id(gang_count) < 3);
+          sl_button_3_action->set_internal(id(gang_count) < 3);
           bs_button_4->publish_state(false);
-          bs_button_4->set_internal(num_gangs < 4);
-          sl_button_4_action->set_internal(num_gangs < 4);
+          bs_button_4->set_internal(id(gang_count) < 4);
+          sl_button_4_action->set_internal(id(gang_count) < 4);
 
   - id: button_action
     mode: parallel

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
@@ -435,6 +435,11 @@ script:
           light_us_left->set_internal(!id(is_us_model));
           light_us_right->set_internal(!id(is_us_model));
           light_us_top->set_internal(!id(is_us_model));
+
+          // LED Group Assignment:
+          // - For US model: gb_lights_1 = left side LEDs, gb_lights_2 = right side LEDs
+          // - For EU model: gb_lights_1 = bottom LEDs, gb_lights_2 = top LEDs
+          // Gang configurations determine which LED segments are active
           switch (id(gang_count)) {
             case 1:  // 1 Gang
               if (id(is_us_model)) {

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
@@ -28,7 +28,6 @@ substitutions:
   LIGHT_FULL_RESTORE_MODE: RESTORE_DEFAULT_OFF
   LIGHT_SIDES_RESTORE_MODE: RESTORE_DEFAULT_OFF
   LIGHT_INDIVIDUAL_RESTORE_MODE: RESTORE_DEFAULT_OFF
-  LIGHT_RELAYS_RESTORE_MODE: RESTORE_DEFAULT_OFF
 
 globals:
   - id: gb_lights_1
@@ -418,334 +417,27 @@ light:
         from: 31
         to: 31
 
-  # These lights are used to indicate relay's statuses
-  - &light_partition_relays
-    id: light_eu_rl_1_1_bottom
-    name: Light - Relay 1 of 1 (bottom)
-    platform: partition
-    internal: true
-    default_transition_length: ${default_transition_length}
-    restore_mode: ${LIGHT_RELAYS_RESTORE_MODE}
-    segments:
-      - id: light_full
-        from: 9
-        to: 9
-  - id: light_eu_rl_1_1_top
-    name: Light - Relay 1 of 1 (top)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 23
-        to: 23
-  - id: light_eu_rl_1_2_bottom
-    name: Light - Relay 1 of 2 (bottom)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 11
-        to: 11
-  - id: light_eu_rl_1_2_top
-    name: Light - Relay 1 of 2 (top)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 21
-        to: 21
-  - id: light_eu_rl_2_2_bottom
-    name: Light - Relay 2 of 2 (bottom)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 7
-        to: 7
-  - id: light_eu_rl_2_2_top
-    name: Light - Relay 2 of 2 (top)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 25
-        to: 25
-  - id: light_eu_rl_1_3_bottom
-    name: Light - Relay 1 of 3 (bottom)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 12
-        to: 12
-  - id: light_eu_rl_1_3_top
-    name: Light - Relay 1 of 3 (top)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 20
-        to: 20
-  - id: light_eu_rl_2_3_bottom
-    name: Light - Relay 2 of 3 (bottom)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 9
-        to: 9
-  - id: light_eu_rl_2_3_top
-    name: Light - Relay 2 of 3 (top)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 23
-        to: 23
-  - id: light_eu_rl_3_3_bottom
-    name: Light - Relay 3 of 3 (bottom)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 6
-        to: 6
-  - id: light_eu_rl_3_3_top
-    name: Light - Relay 3 of 3 (top)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 26
-        to: 26
-  - id: light_eu_rl_1_4_bottom
-    name: Light - Relay 1 of 4 (bottom)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 12
-        to: 12
-  - id: light_eu_rl_1_4_top
-    name: Light - Relay 1 of 4 (top)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 20
-        to: 20
-  - id: light_eu_rl_2_4_bottom
-    name: Light - Relay 2 of 4 (bottom)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 10
-        to: 10
-  - id: light_eu_rl_2_4_top
-    name: Light - Relay 2 of 4 (top)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 22
-        to: 22
-  - id: light_eu_rl_3_4_bottom
-    name: Light - Relay 3 of 4 (bottom)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 8
-        to: 8
-  - id: light_eu_rl_3_4_top
-    name: Light - Relay 3 of 4 (top)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 24
-        to: 24
-  - id: light_eu_rl_4_4_bottom
-    name: Light - Relay 4 of 4 (bottom)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 6
-        to: 6
-  - id: light_eu_rl_4_4_top
-    name: Light - Relay 4 of 4 (top)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 26
-        to: 26
-  - id: light_us_rl_1_1_left
-    name: Light - Relay 1 of 1 (left)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 15
-        to: 24
-  - id: light_us_rl_1_1_right
-    name: Light - Relay 1 of 1 (right)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 31
-        to: 31
-      - id: light_full
-        from: 0
-        to: 8
-  - id: light_us_rl_1_2_left
-    name: Light - Relay 1 of 2 (left)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 20
-        to: 24
-  - id: light_us_rl_1_2_right
-    name: Light - Relay 1 of 2 (right)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 31
-        to: 31
-      - id: light_full
-        from: 0
-        to: 3
-  - id: light_us_rl_2_2_left
-    name: Light - Relay 2 of 2 (left)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 15
-        to: 19
-  - id: light_us_rl_2_2_right
-    name: Light - Relay 2 of 2 (right)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 4
-        to: 8
-  - id: light_us_rl_1_3_left
-    name: Light - Relay 1 of 3 (left)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 22
-        to: 23
-  - id: light_us_rl_1_3_right
-    name: Light - Relay 1 of 3 (right)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 0
-        to: 1
-  - id: light_us_rl_2_3_left
-    name: Light - Relay 2 of 3 (left)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 19
-        to: 20
-  - id: light_us_rl_2_3_right
-    name: Light - Relay 2 of 3 (right)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 3
-        to: 4
-  - id: light_us_rl_3_3_left
-    name: Light - Relay 3 of 3 (left)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 16
-        to: 17
-  - id: light_us_rl_3_3_right
-    name: Light - Relay 3 of 3 (right)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 6
-        to: 7
-  - id: light_us_rl_1_4_left
-    name: Light - Relay 1 of 4 (left)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 23
-        to: 24
-  - id: light_us_rl_1_4_right
-    name: Light - Relay 1 of 4 (right)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 31
-        to: 31
-      - id: light_full
-        from: 0
-        to: 0
-  - id: light_us_rl_2_4_left
-    name: Light - Relay 2 of 4 (left)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 21
-        to: 22
-  - id: light_us_rl_2_4_right
-    name: Light - Relay 2 of 4 (right)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 1
-        to: 2
-  - id: light_us_rl_3_4_left
-    name: Light - Relay 3 of 4 (left)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 17
-        to: 18
-  - id: light_us_rl_3_4_right
-    name: Light - Relay 3 of 4 (right)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 5
-        to: 6
-  - id: light_us_rl_4_4_left
-    name: Light - Relay 4 of 4 (left)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 15
-        to: 16
-  - id: light_us_rl_4_4_right
-    name: Light - Relay 4 of 4 (right)
-    <<: *light_partition_relays
-    segments:
-      - id: light_full
-        from: 7
-        to: 8
-
 script:
   - id: !extend boot_initialize
     then:
-      - wait_until:
-          condition:
-            - lambda: return sl_tx_model_format->active_index().has_value();
-            - lambda: return sl_tx_model_gang->active_index().has_value();
       - lambda: |-
-          const bool is_model_us = sl_tx_model_format->active_index().has_value() and
-                                    sl_tx_model_format->active_index().value() == 1;
-          const uint8_t num_gangs = (sl_tx_model_gang->active_index().has_value()) ?
-                                    (sl_tx_model_gang->active_index().value() + 1) : 0;
-          if (num_gangs < 1 || num_gangs > 4) {
-            ESP_LOGE("core_hw_leds", "Invalid number of gangs: %" PRIu8, num_gangs);
-            return;
-          }
-          light_28->set_internal(!is_model_us);
-          light_29->set_internal(!is_model_us);
-          light_30->set_internal(!is_model_us);
-          light_31->set_internal(!is_model_us);
-          light_eu->set_internal(is_model_us);
-          light_eu_bottom->set_internal(is_model_us);
-          light_eu_left->set_internal(is_model_us);
-          light_eu_right->set_internal(is_model_us);
-          light_eu_top->set_internal(is_model_us);
-          light_us->set_internal(!is_model_us);
-          light_us_bottom->set_internal(!is_model_us);
-          light_us_left->set_internal(!is_model_us);
-          light_us_right->set_internal(!is_model_us);
-          light_us_top->set_internal(!is_model_us);
-          switch (num_gangs) {
+          light_28->set_internal(!id(is_us_model));
+          light_29->set_internal(!id(is_us_model));
+          light_30->set_internal(!id(is_us_model));
+          light_31->set_internal(!id(is_us_model));
+          light_eu->set_internal(id(is_us_model));
+          light_eu_bottom->set_internal(id(is_us_model));
+          light_eu_left->set_internal(id(is_us_model));
+          light_eu_right->set_internal(id(is_us_model));
+          light_eu_top->set_internal(id(is_us_model));
+          light_us->set_internal(!id(is_us_model));
+          light_us_bottom->set_internal(!id(is_us_model));
+          light_us_left->set_internal(!id(is_us_model));
+          light_us_right->set_internal(!id(is_us_model));
+          light_us_top->set_internal(!id(is_us_model));
+          switch (id(gang_count)) {
             case 1:  // 1 Gang
-              if (is_model_us) {
+              if (id(is_us_model)) {
                 id(gb_lights_1) = { light_us_rl_1_1_left };
                 id(gb_lights_2) = { light_us_rl_1_1_right };
               } else {
@@ -754,7 +446,7 @@ script:
               }
               break;
             case 2:  // 2 Gang
-              if (is_model_us) {
+              if (id(is_us_model)) {
                 id(gb_lights_1) = { light_us_rl_1_2_left, light_us_rl_2_2_left };
                 id(gb_lights_2) = { light_us_rl_1_2_right, light_us_rl_2_2_right };
               } else {
@@ -763,7 +455,7 @@ script:
               }
               break;
             case 3:  // 3 Gang
-              if (is_model_us) {
+              if (id(is_us_model)) {
                 id(gb_lights_1) = { light_us_rl_1_3_left, light_us_rl_2_3_left, light_us_rl_3_3_left };
                 id(gb_lights_2) = { light_us_rl_1_3_right, light_us_rl_2_3_right, light_us_rl_3_3_right };
               } else {
@@ -772,7 +464,7 @@ script:
               }
               break;
             case 4:  // 4 Gang
-              if (is_model_us) {
+              if (id(is_us_model)) {
                 id(gb_lights_1) = { light_us_rl_1_4_left, light_us_rl_2_4_left,
                                     light_us_rl_3_4_left, light_us_rl_4_4_left };
                 id(gb_lights_2) = { light_us_rl_1_4_right, light_us_rl_2_4_right,
@@ -798,10 +490,12 @@ script:
           static const uint32_t LIGHT_TRANSITION_TURN_OFF = ${LIGHT_TRANSITION_TURN_OFF};
           static const uint8_t LIGHT_BRIGHTNESS_TURN_ON = ${LIGHT_BRIGHTNESS_TURN_ON};
 
-          const bool is_model_us = sl_tx_model_format->active_index().has_value() and
-                                    sl_tx_model_format->active_index().value() == 1;
-          const std::string light_mode_group_1 = is_model_us ? "${LIGHT_MODE_LEFT_TEXT}" : "${LIGHT_MODE_BOTTOM_TEXT}";
-          const std::string light_mode_group_2 = is_model_us ? "${LIGHT_MODE_RIGHT_TEXT}" : "${LIGHT_MODE_TOP_TEXT}";
+          const std::string light_mode_group_1 = id(is_us_model)
+                                                  ? "${LIGHT_MODE_LEFT_TEXT}"
+                                                  : "${LIGHT_MODE_BOTTOM_TEXT}";
+          const std::string light_mode_group_2 = id(is_us_model)
+                                                  ? "${LIGHT_MODE_RIGHT_TEXT}"
+                                                  : "${LIGHT_MODE_TOP_TEXT}";
 
           switch (light_group) {
             case 1:

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_relays.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_relays.yaml
@@ -25,6 +25,18 @@ globals:
     type: bool
     restore_value: false
     initial_value: 'false'
+  - id: boot_initialization_relays_light_modes
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+  - id: boot_initialization_relays_relay_leds
+    type: bool
+    restore_value: false
+    initial_value: 'false'
+  - id: boot_initialization_relays_relay_modes
+    type: bool
+    restore_value: false
+    initial_value: 'false'
 
 light:
   # These lights are used for the physical relays to be shown as lights
@@ -424,19 +436,112 @@ script:
   - id: boot_initialize_relays
     mode: restart
     then:
+      - script.execute: boot_initialize_relays_light_modes
+      - script.execute: boot_initialize_relays_relay_leds
+      - script.execute: boot_initialize_relays_relay_modes
+      - script.wait: boot_initialize_relays_light_modes
+      - script.wait: boot_initialize_relays_relay_leds
+      - script.wait: boot_initialize_relays_relay_modes
+      - wait_until:
+          condition:
+            - lambda: return id(boot_initialization_relays_light_modes);
+            - lambda: return id(boot_initialization_relays_relay_leds);
+            - lambda: return id(boot_initialization_relays_relay_modes);
+      - globals.set:
+          id: boot_initialization_relays
+          value: 'true'
+
+  - id: boot_initialize_relays_light_modes
+    mode: restart
+    then:
       - lambda: |-
-          sl_relay_1_mode->set_internal(id(gang_count) < 1);
+          // EU light modes
           sl_relay_1_light_mode_eu->set_internal(id(is_us_model) or id(gang_count) < 1);
-          sl_relay_1_light_mode_us->set_internal(!id(is_us_model) or id(gang_count) < 1);
-          sl_relay_2_mode->set_internal(id(gang_count) < 2);
           sl_relay_2_light_mode_eu->set_internal(id(is_us_model) or id(gang_count) < 2);
-          sl_relay_2_light_mode_us->set_internal(!id(is_us_model) or id(gang_count) < 2);
-          sl_relay_3_mode->set_internal(id(gang_count) < 3);
           sl_relay_3_light_mode_eu->set_internal(id(is_us_model) or id(gang_count) < 3);
-          sl_relay_3_light_mode_us->set_internal(!id(is_us_model) or id(gang_count) < 3);
-          sl_relay_4_mode->set_internal(id(gang_count) < 4);
           sl_relay_4_light_mode_eu->set_internal(id(is_us_model) or id(gang_count) < 4);
+
+          // US light modes
+          sl_relay_1_light_mode_us->set_internal(!id(is_us_model) or id(gang_count) < 1);
+          sl_relay_2_light_mode_us->set_internal(!id(is_us_model) or id(gang_count) < 2);
+          sl_relay_3_light_mode_us->set_internal(!id(is_us_model) or id(gang_count) < 3);
           sl_relay_4_light_mode_us->set_internal(!id(is_us_model) or id(gang_count) < 4);
+
+          // Set this section of initialization as completed
+          id(boot_initialization_relays_light_modes) = true;
+
+  - id: boot_initialize_relays_relay_leds
+    mode: restart
+    then:
+      - lambda: |-
+          const bool set_internal = not sw_expose_relays_leds_to_ha->state;
+
+          // EU model LEDs
+          // EU model - 1 Gang
+          light_eu_rl_1_1_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 1);
+          light_eu_rl_1_1_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 1);
+          // EU model - 2 Gang
+          light_eu_rl_1_2_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 2);
+          light_eu_rl_1_2_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 2);
+          light_eu_rl_2_2_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 2);
+          light_eu_rl_2_2_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 2);
+          // EU model - 3 Gang
+          light_eu_rl_1_3_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
+          light_eu_rl_1_3_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
+          light_eu_rl_2_3_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
+          light_eu_rl_2_3_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
+          light_eu_rl_3_3_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
+          light_eu_rl_3_3_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
+          // EU model - 4 Gang
+          light_eu_rl_1_4_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_eu_rl_1_4_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_eu_rl_2_4_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_eu_rl_2_4_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_eu_rl_3_4_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_eu_rl_3_4_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_eu_rl_4_4_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_eu_rl_4_4_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+
+          // US model LEDs
+          // US model - 1 Gang
+          light_us_rl_1_1_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 1);
+          light_us_rl_1_1_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 1);
+          // US model - 2 Gang
+          light_us_rl_1_2_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 2);
+          light_us_rl_1_2_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 2);
+          light_us_rl_2_2_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 2);
+          light_us_rl_2_2_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 2);
+          // US model - 3 Gang
+          light_us_rl_1_3_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
+          light_us_rl_1_3_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
+          light_us_rl_2_3_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
+          light_us_rl_2_3_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
+          light_us_rl_3_3_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
+          light_us_rl_3_3_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
+          // US model - 4 Gang
+          light_us_rl_1_4_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_1_4_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_2_4_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_2_4_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_3_4_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_3_4_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_4_4_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_4_4_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+
+          // Set this section of initialization as completed
+          id(boot_initialization_relays_relay_leds) = true;
+
+  - id: boot_initialize_relays_relay_modes
+    mode: restart
+    then:
+      - lambda: |-
+          // Set selector internal based on the model (num of relays)
+          sl_relay_1_mode->set_internal(id(gang_count) < 1);
+          sl_relay_2_mode->set_internal(id(gang_count) < 2);
+          sl_relay_3_mode->set_internal(id(gang_count) < 3);
+          sl_relay_4_mode->set_internal(id(gang_count) < 4);
+
+          // Set indicator (either switch or light) visible on Home Assistant
           auto relay_mode_index = sl_relay_1_mode->active_index();
           if (relay_mode_index.has_value()) {
             light_output_1->set_internal(false or relay_mode_index.value() != 1);
@@ -457,48 +562,9 @@ script:
             light_output_4->set_internal(id(gang_count) < 4 or relay_mode_index.value() != 1);
             sw_relay_4->set_internal(id(gang_count) < 4 or relay_mode_index.value() != 0);
           }
-          const bool set_internal = not sw_expose_relays_leds_to_ha->state;
-          light_eu_rl_1_1_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 1);
-          light_eu_rl_1_1_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 1);
-          light_eu_rl_1_2_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 2);
-          light_eu_rl_1_2_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 2);
-          light_eu_rl_2_2_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 2);
-          light_eu_rl_2_2_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 2);
-          light_eu_rl_1_3_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
-          light_eu_rl_1_3_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
-          light_eu_rl_2_3_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
-          light_eu_rl_2_3_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
-          light_eu_rl_3_3_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
-          light_eu_rl_3_3_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
-          light_eu_rl_1_4_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
-          light_eu_rl_1_4_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
-          light_eu_rl_2_4_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
-          light_eu_rl_2_4_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
-          light_eu_rl_3_4_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
-          light_eu_rl_3_4_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
-          light_eu_rl_4_4_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
-          light_eu_rl_4_4_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
-          light_us_rl_1_1_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 1);
-          light_us_rl_1_1_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 1);
-          light_us_rl_1_2_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 2);
-          light_us_rl_1_2_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 2);
-          light_us_rl_2_2_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 2);
-          light_us_rl_2_2_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 2);
-          light_us_rl_1_3_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
-          light_us_rl_1_3_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
-          light_us_rl_2_3_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
-          light_us_rl_2_3_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
-          light_us_rl_3_3_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
-          light_us_rl_3_3_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
-          light_us_rl_1_4_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
-          light_us_rl_1_4_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
-          light_us_rl_2_4_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
-          light_us_rl_2_4_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
-          light_us_rl_3_4_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
-          light_us_rl_3_4_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
-          light_us_rl_4_4_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
-          light_us_rl_4_4_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
-          id(boot_initialization_relays) = true;
+
+          // Set this section of initialization as completed
+          id(boot_initialization_relays_relay_modes) = true;
 
   - id: !extend button_click_event
     then:

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_relays.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_relays.yaml
@@ -15,7 +15,10 @@ substitutions:
   RELAY_MODE_TEXT_SWITCH: "Switch"
   RELAY_MODE_TEXT_LIGHT: "Light"
   RELAY_MODE_TEXT_NOT_USED: "Not in use"
+
   RELAY_RESTORE_MODE: RESTORE_DEFAULT_OFF
+  LIGHT_RELAYS_RESTORE_MODE: RESTORE_DEFAULT_OFF
+
 
 globals:
   - id: boot_initialization_relays
@@ -103,19 +106,312 @@ light:
             then:
               - switch.turn_off: sw_relay_4
 
+  # These lights are used to indicate relay's statuses
+  - &light_partition_relays
+    id: light_eu_rl_1_1_bottom
+    name: Light - Relay 1 of 1 (bottom)
+    platform: partition
+    internal: true
+    disabled_by_default: true
+    default_transition_length: ${default_transition_length}
+    restore_mode: ${LIGHT_RELAYS_RESTORE_MODE}
+    segments:
+      - id: light_full
+        from: 9
+        to: 9
+  - id: light_eu_rl_1_1_top
+    name: Light - Relay 1 of 1 (top)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 23
+        to: 23
+  - id: light_eu_rl_1_2_bottom
+    name: Light - Relay 1 of 2 (bottom)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 11
+        to: 11
+  - id: light_eu_rl_1_2_top
+    name: Light - Relay 1 of 2 (top)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 21
+        to: 21
+  - id: light_eu_rl_2_2_bottom
+    name: Light - Relay 2 of 2 (bottom)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 7
+        to: 7
+  - id: light_eu_rl_2_2_top
+    name: Light - Relay 2 of 2 (top)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 25
+        to: 25
+  - id: light_eu_rl_1_3_bottom
+    name: Light - Relay 1 of 3 (bottom)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 12
+        to: 12
+  - id: light_eu_rl_1_3_top
+    name: Light - Relay 1 of 3 (top)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 20
+        to: 20
+  - id: light_eu_rl_2_3_bottom
+    name: Light - Relay 2 of 3 (bottom)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 9
+        to: 9
+  - id: light_eu_rl_2_3_top
+    name: Light - Relay 2 of 3 (top)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 23
+        to: 23
+  - id: light_eu_rl_3_3_bottom
+    name: Light - Relay 3 of 3 (bottom)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 6
+        to: 6
+  - id: light_eu_rl_3_3_top
+    name: Light - Relay 3 of 3 (top)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 26
+        to: 26
+  - id: light_eu_rl_1_4_bottom
+    name: Light - Relay 1 of 4 (bottom)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 12
+        to: 12
+  - id: light_eu_rl_1_4_top
+    name: Light - Relay 1 of 4 (top)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 20
+        to: 20
+  - id: light_eu_rl_2_4_bottom
+    name: Light - Relay 2 of 4 (bottom)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 10
+        to: 10
+  - id: light_eu_rl_2_4_top
+    name: Light - Relay 2 of 4 (top)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 22
+        to: 22
+  - id: light_eu_rl_3_4_bottom
+    name: Light - Relay 3 of 4 (bottom)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 8
+        to: 8
+  - id: light_eu_rl_3_4_top
+    name: Light - Relay 3 of 4 (top)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 24
+        to: 24
+  - id: light_eu_rl_4_4_bottom
+    name: Light - Relay 4 of 4 (bottom)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 6
+        to: 6
+  - id: light_eu_rl_4_4_top
+    name: Light - Relay 4 of 4 (top)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 26
+        to: 26
+  - id: light_us_rl_1_1_left
+    name: Light - Relay 1 of 1 (left)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 15
+        to: 24
+  - id: light_us_rl_1_1_right
+    name: Light - Relay 1 of 1 (right)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 31
+        to: 31
+      - id: light_full
+        from: 0
+        to: 8
+  - id: light_us_rl_1_2_left
+    name: Light - Relay 1 of 2 (left)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 20
+        to: 24
+  - id: light_us_rl_1_2_right
+    name: Light - Relay 1 of 2 (right)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 31
+        to: 31
+      - id: light_full
+        from: 0
+        to: 3
+  - id: light_us_rl_2_2_left
+    name: Light - Relay 2 of 2 (left)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 15
+        to: 19
+  - id: light_us_rl_2_2_right
+    name: Light - Relay 2 of 2 (right)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 4
+        to: 8
+  - id: light_us_rl_1_3_left
+    name: Light - Relay 1 of 3 (left)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 22
+        to: 23
+  - id: light_us_rl_1_3_right
+    name: Light - Relay 1 of 3 (right)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 0
+        to: 1
+  - id: light_us_rl_2_3_left
+    name: Light - Relay 2 of 3 (left)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 19
+        to: 20
+  - id: light_us_rl_2_3_right
+    name: Light - Relay 2 of 3 (right)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 3
+        to: 4
+  - id: light_us_rl_3_3_left
+    name: Light - Relay 3 of 3 (left)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 16
+        to: 17
+  - id: light_us_rl_3_3_right
+    name: Light - Relay 3 of 3 (right)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 6
+        to: 7
+  - id: light_us_rl_1_4_left
+    name: Light - Relay 1 of 4 (left)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 23
+        to: 24
+  - id: light_us_rl_1_4_right
+    name: Light - Relay 1 of 4 (right)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 31
+        to: 31
+      - id: light_full
+        from: 0
+        to: 0
+  - id: light_us_rl_2_4_left
+    name: Light - Relay 2 of 4 (left)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 21
+        to: 22
+  - id: light_us_rl_2_4_right
+    name: Light - Relay 2 of 4 (right)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 1
+        to: 2
+  - id: light_us_rl_3_4_left
+    name: Light - Relay 3 of 4 (left)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 17
+        to: 18
+  - id: light_us_rl_3_4_right
+    name: Light - Relay 3 of 4 (right)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 5
+        to: 6
+  - id: light_us_rl_4_4_left
+    name: Light - Relay 4 of 4 (left)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 15
+        to: 16
+  - id: light_us_rl_4_4_right
+    name: Light - Relay 4 of 4 (right)
+    <<: *light_partition_relays
+    segments:
+      - id: light_full
+        from: 7
+        to: 8
+
 output:
   - id: output_relay_1
     platform: gpio
     pin: GPIO18
-
   - id: output_relay_2
     platform: gpio
     pin: GPIO17
-
   - id: output_relay_3
     platform: gpio
     pin: GPIO27
-
   - id: output_relay_4
     platform: gpio
     pin: GPIO23
@@ -128,31 +424,19 @@ script:
   - id: boot_initialize_relays
     mode: restart
     then:
-      - wait_until:
-          condition:
-            - lambda: return sl_tx_model_format->active_index().has_value();
-            - lambda: return sl_tx_model_gang->active_index().has_value();
       - lambda: |-
-          const bool is_model_us = sl_tx_model_format->active_index().has_value() and
-                                    sl_tx_model_format->active_index().value() == 1;
-          const uint8_t num_gangs = (sl_tx_model_gang->active_index().has_value()) ?
-                                    (sl_tx_model_gang->active_index().value() + 1) : 0;
-          if (num_gangs < 1 || num_gangs > 4) {
-            ESP_LOGE("core_hw_relays", "Invalid number of gangs: %" PRIu8, num_gangs);
-            return;
-          }
-          sl_relay_1_mode->set_internal(num_gangs < 1);
-          sl_relay_1_light_mode_eu->set_internal(is_model_us or num_gangs < 1);
-          sl_relay_1_light_mode_us->set_internal(!is_model_us or num_gangs < 1);
-          sl_relay_2_mode->set_internal(num_gangs < 2);
-          sl_relay_2_light_mode_eu->set_internal(is_model_us or num_gangs < 2);
-          sl_relay_2_light_mode_us->set_internal(!is_model_us or num_gangs < 2);
-          sl_relay_3_mode->set_internal(num_gangs < 3);
-          sl_relay_3_light_mode_eu->set_internal(is_model_us or num_gangs < 3);
-          sl_relay_3_light_mode_us->set_internal(!is_model_us or num_gangs < 3);
-          sl_relay_4_mode->set_internal(num_gangs < 4);
-          sl_relay_4_light_mode_eu->set_internal(is_model_us or num_gangs < 4);
-          sl_relay_4_light_mode_us->set_internal(!is_model_us or num_gangs < 4);
+          sl_relay_1_mode->set_internal(id(gang_count) < 1);
+          sl_relay_1_light_mode_eu->set_internal(id(is_us_model) or id(gang_count) < 1);
+          sl_relay_1_light_mode_us->set_internal(!id(is_us_model) or id(gang_count) < 1);
+          sl_relay_2_mode->set_internal(id(gang_count) < 2);
+          sl_relay_2_light_mode_eu->set_internal(id(is_us_model) or id(gang_count) < 2);
+          sl_relay_2_light_mode_us->set_internal(!id(is_us_model) or id(gang_count) < 2);
+          sl_relay_3_mode->set_internal(id(gang_count) < 3);
+          sl_relay_3_light_mode_eu->set_internal(id(is_us_model) or id(gang_count) < 3);
+          sl_relay_3_light_mode_us->set_internal(!id(is_us_model) or id(gang_count) < 3);
+          sl_relay_4_mode->set_internal(id(gang_count) < 4);
+          sl_relay_4_light_mode_eu->set_internal(id(is_us_model) or id(gang_count) < 4);
+          sl_relay_4_light_mode_us->set_internal(!id(is_us_model) or id(gang_count) < 4);
           auto relay_mode_index = sl_relay_1_mode->active_index();
           if (relay_mode_index.has_value()) {
             light_output_1->set_internal(false or relay_mode_index.value() != 1);
@@ -160,19 +444,60 @@ script:
           }
           relay_mode_index = sl_relay_2_mode->active_index();
           if (relay_mode_index.has_value()) {
-            light_output_2->set_internal(num_gangs < 2 or relay_mode_index.value() != 1);
-            sw_relay_2->set_internal(num_gangs < 2 or relay_mode_index.value() != 0);
+            light_output_2->set_internal(id(gang_count) < 2 or relay_mode_index.value() != 1);
+            sw_relay_2->set_internal(id(gang_count) < 2 or relay_mode_index.value() != 0);
           }
           relay_mode_index = sl_relay_3_mode->active_index();
           if (relay_mode_index.has_value()) {
-            light_output_3->set_internal(num_gangs < 3 or relay_mode_index.value() != 1);
-            sw_relay_3->set_internal(num_gangs < 3 or relay_mode_index.value() != 0);
+            light_output_3->set_internal(id(gang_count) < 3 or relay_mode_index.value() != 1);
+            sw_relay_3->set_internal(id(gang_count) < 3 or relay_mode_index.value() != 0);
           }
           relay_mode_index = sl_relay_4_mode->active_index();
           if (relay_mode_index.has_value()) {
-            light_output_4->set_internal(num_gangs < 4 or relay_mode_index.value() != 1);
-            sw_relay_4->set_internal(num_gangs < 4 or relay_mode_index.value() != 0);
+            light_output_4->set_internal(id(gang_count) < 4 or relay_mode_index.value() != 1);
+            sw_relay_4->set_internal(id(gang_count) < 4 or relay_mode_index.value() != 0);
           }
+          const bool set_internal = not sw_expose_relays_leds_to_ha->state;
+          light_eu_rl_1_1_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 1);
+          light_eu_rl_1_1_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 1);
+          light_eu_rl_1_2_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 2);
+          light_eu_rl_1_2_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 2);
+          light_eu_rl_2_2_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 2);
+          light_eu_rl_2_2_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 2);
+          light_eu_rl_1_3_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
+          light_eu_rl_1_3_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
+          light_eu_rl_2_3_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
+          light_eu_rl_2_3_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
+          light_eu_rl_3_3_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
+          light_eu_rl_3_3_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 3);
+          light_eu_rl_1_4_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_eu_rl_1_4_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_eu_rl_2_4_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_eu_rl_2_4_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_eu_rl_3_4_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_eu_rl_3_4_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_eu_rl_4_4_bottom->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_eu_rl_4_4_top->set_internal(set_internal or id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_1_1_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 1);
+          light_us_rl_1_1_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 1);
+          light_us_rl_1_2_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 2);
+          light_us_rl_1_2_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 2);
+          light_us_rl_2_2_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 2);
+          light_us_rl_2_2_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 2);
+          light_us_rl_1_3_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
+          light_us_rl_1_3_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
+          light_us_rl_2_3_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
+          light_us_rl_2_3_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
+          light_us_rl_3_3_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
+          light_us_rl_3_3_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 3);
+          light_us_rl_1_4_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_1_4_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_2_4_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_2_4_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_3_4_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_3_4_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_4_4_left->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
+          light_us_rl_4_4_right->set_internal(set_internal or !id(is_us_model) or id(gang_count) != 4);
           id(boot_initialization_relays) = true;
 
   - id: !extend button_click_event
@@ -247,28 +572,20 @@ script:
     mode: restart
     then:
       - script.wait: boot_initialize_relays
-      - wait_until:
-          condition:
-            - lambda: return id(boot_initialization_relays);
       - lambda: |-
-          const bool is_model_us = sl_tx_model_format->active_index().has_value() and
-                                    sl_tx_model_format->active_index().value() == 1;
-          const uint8_t num_gangs = (sl_tx_model_gang->active_index().has_value())
-                                      ? (sl_tx_model_gang->active_index().value() + 1)
-                                      : 0;
-
-          if (num_gangs < 1 || num_gangs > 4) {
-            ESP_LOGE("core_hw_relays", "Invalid number of gangs: %" PRIu8, num_gangs);
+          if (not id(boot_initialization_relays)) {
+            ESP_LOGW("core_hw_relays", "Relays not initialized yet");
+            if (not boot_initialize_relays->is_running())
+              boot_initialize_relays->execute();
             return;
           }
-
-          for (uint8_t i = 0; i < num_gangs; i++) {
+          for (uint8_t i = 0; i < id(gang_count); i++) {
             bool relay_state = false;
             std::string light_mode;
-            const std::string light_mode_group_1 = is_model_us
+            const std::string light_mode_group_1 = id(is_us_model)
                                                     ? "${LIGHT_MODE_LEFT_TEXT}"
                                                     : "${LIGHT_MODE_BOTTOM_TEXT}";
-            const std::string light_mode_group_2 = is_model_us
+            const std::string light_mode_group_2 = id(is_us_model)
                                                     ? "${LIGHT_MODE_RIGHT_TEXT}"
                                                     : "${LIGHT_MODE_TOP_TEXT}";
 
@@ -276,25 +593,25 @@ script:
             switch (i) {
               case 0:
                 relay_state = id(sw_relay_1).state;
-                light_mode = is_model_us
+                light_mode = id(is_us_model)
                               ? id(sl_relay_1_light_mode_us)->state
                               : id(sl_relay_1_light_mode_eu)->state;
                 break;
               case 1:
                 relay_state = id(sw_relay_2).state;
-                light_mode = is_model_us
+                light_mode = id(is_us_model)
                               ? id(sl_relay_2_light_mode_us)->state
                               : id(sl_relay_2_light_mode_eu)->state;
                 break;
               case 2:
                 relay_state = id(sw_relay_3).state;
-                light_mode = is_model_us
+                light_mode = id(is_us_model)
                               ? id(sl_relay_3_light_mode_us)->state
                               : id(sl_relay_3_light_mode_eu)->state;
                 break;
               case 3:
                 relay_state = id(sw_relay_4).state;
-                light_mode = is_model_us
+                light_mode = id(is_us_model)
                               ? id(sl_relay_4_light_mode_us)->state
                               : id(sl_relay_4_light_mode_eu)->state;
                 break;
@@ -333,20 +650,40 @@ select:
     entity_category: config
     disabled_by_default: false
     icon: mdi:dip-switch
-
+    on_value:
+      then:
+        - binary_sensor.template.publish:
+            id: bs_pending_restart
+            state: true
   - id: sl_relay_2_mode
     name: Relay 2 display mode
     <<: *relay_select_mode_base
-
   - id: sl_relay_3_mode
     name: Relay 3 display mode
     <<: *relay_select_mode_base
-
   - id: sl_relay_4_mode
     name: Relay 4 display mode
     <<: *relay_select_mode_base
 
 switch:
+  - id: sw_expose_relays_leds_to_ha
+    name: Expose Relay's LEDs to Home Assistant
+    platform: template
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: true
+    internal: false
+    entity_category: config
+    on_turn_on:
+      then:
+        - binary_sensor.template.publish:
+            id: bs_pending_restart
+            state: true
+    on_turn_off:
+      then:
+        - binary_sensor.template.publish:
+            id: bs_pending_restart
+            state: true
+
   - id: sw_relay_1
     name: Relay 1
     output: output_relay_1
@@ -369,7 +706,6 @@ switch:
               - light.is_on: light_output_1
             then:
               - light.turn_off: light_output_1
-
   - id: sw_relay_2
     name: Relay 2
     output: output_relay_2
@@ -392,7 +728,6 @@ switch:
               - light.is_on: light_output_2
             then:
               - light.turn_off: light_output_2
-
   - id: sw_relay_3
     name: Relay 3
     output: output_relay_3
@@ -415,7 +750,6 @@ switch:
               - light.is_on: light_output_3
             then:
               - light.turn_off: light_output_3
-
   - id: sw_relay_4
     name: Relay 4
     output: output_relay_4

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_speaker.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_speaker.yaml
@@ -2,7 +2,7 @@
 #####                              TX Ultimate Easy for ESPHome                                #####
 #####                  Repository: https://github.com/edwardtfn/TX-Ultimate-Easy               #####
 ####################################################################################################
-##### Purpose: ESPHome Core - Hardware - Speaker                                               #####
+##### Purpose: ESPHome Core - Hardware - Media player                                          #####
 ####################################################################################################
 ##### Author: edwardtfn - https://github.com/edwardtfn - https://buymeacoffee.com/edwardfirmo  #####
 ####################################################################################################
@@ -17,8 +17,8 @@ i2s_audio:
   i2s_lrclk_pin: GPIO4
 
 media_player:
-  - id: mp_speaker
-    name: Speaker
+  - id: mp_media_player
+    name: Media Player
     internal: false
     platform: i2s_audio
     i2s_dout_pin: GPIO15

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_touch.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_touch.yaml
@@ -256,13 +256,8 @@ script:
   - id: boot_initialize_touch_gang
     mode: restart
     then:
-      - wait_until:
-          condition:
-            - lambda: return sl_tx_model_gang->active_index().has_value();
       - lambda: |-
-          const uint8_t num_gangs = (sl_tx_model_gang->active_index().has_value()) ?
-                                    (sl_tx_model_gang->active_index().value() + 1) : 0;
-          tx_ultimate->set_gang_count(num_gangs);
+          tx_ultimate->set_gang_count(id(gang_count));
           bs_button_1_click_event->publish_state(false);
           bs_button_2_click_event->publish_state(false);
           bs_button_3_click_event->publish_state(false);
@@ -275,18 +270,18 @@ script:
           bs_button_2_long_press_event->publish_state(false);
           bs_button_3_long_press_event->publish_state(false);
           bs_button_4_long_press_event->publish_state(false);
-          bs_button_1_click_event->set_internal(num_gangs < 1);
-          bs_button_2_click_event->set_internal(num_gangs < 2);
-          bs_button_3_click_event->set_internal(num_gangs < 3);
-          bs_button_4_click_event->set_internal(num_gangs < 4);
-          bs_button_1_double_click_event->set_internal(num_gangs < 1);
-          bs_button_2_double_click_event->set_internal(num_gangs < 2);
-          bs_button_3_double_click_event->set_internal(num_gangs < 3);
-          bs_button_4_double_click_event->set_internal(num_gangs < 4);
-          bs_button_1_long_press_event->set_internal(num_gangs < 1);
-          bs_button_2_long_press_event->set_internal(num_gangs < 2);
-          bs_button_3_long_press_event->set_internal(num_gangs < 3);
-          bs_button_4_long_press_event->set_internal(num_gangs < 4);
+          bs_button_1_click_event->set_internal(id(gang_count) < 1);
+          bs_button_2_click_event->set_internal(id(gang_count) < 2);
+          bs_button_3_click_event->set_internal(id(gang_count) < 3);
+          bs_button_4_click_event->set_internal(id(gang_count) < 4);
+          bs_button_1_double_click_event->set_internal(id(gang_count) < 1);
+          bs_button_2_double_click_event->set_internal(id(gang_count) < 2);
+          bs_button_3_double_click_event->set_internal(id(gang_count) < 3);
+          bs_button_4_double_click_event->set_internal(id(gang_count) < 4);
+          bs_button_1_long_press_event->set_internal(id(gang_count) < 1);
+          bs_button_2_long_press_event->set_internal(id(gang_count) < 2);
+          bs_button_3_long_press_event->set_internal(id(gang_count) < 3);
+          bs_button_4_long_press_event->set_internal(id(gang_count) < 4);
 
   - id: touch_on_multi_touch_release
     mode: restart


### PR DESCRIPTION
The lights will be available on Home Assistant, so users will be able to set it's color and brightness, then this will be used when the relay turn on-off as the indicator for the relay status.
Resolves #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new binary sensor, `bs_pending_restart`, to track pending restart status.
	- Added multiple new light entities for relay configurations.
	- Changed the designation of a component from "Speaker" to "Media Player."

- **Bug Fixes**
	- Enhanced handling of gang count during initialization, improving state management.

- **Refactor**
	- Streamlined logic for button and relay state management, improving clarity and maintainability.
	- Updated initialization logic to reduce complexity and improve readability.

- **Chores**
	- Updated internal identifiers and variable names for consistency across configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->