### PR TITLE
Set relays lights to not be disabled when exposed

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_standard_hw_relays.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_standard_hw_relays.yaml
@@ -132,7 +132,7 @@ light:
     name: Light - Relay 1 of 1 (bottom)
     platform: partition
     internal: true
-    disabled_by_default: true
+    disabled_by_default: false
     default_transition_length: ${default_transition_length}
     restore_mode: ${LIGHT_RELAYS_RESTORE_MODE}
     segments:


### PR DESCRIPTION
Resolves #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The light `light_eu_rl_1_1_bottom` is now enabled by default upon system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->