### PR TITLE
Fix rainbow effect loop by setting correct width per model.

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
@@ -54,20 +54,15 @@ light:
     type: GRB
     variant: WS2811
 
-  # Those lights are available based on the model selections
-  - &light_partition_with_effects
-    id: light_eu
-    name: Light EU
+  # Those lights contain common effects for both models
+  - &light_partition_with_effects_common
+    id: light_base
+    name: Light Base
     platform: partition
     default_transition_length: ${default_transition_length}
     internal: true
     restore_mode: ${LIGHT_SIDES_RESTORE_MODE}
     effects:
-      - addressable_rainbow:
-          name: "Rainbow"
-      - addressable_rainbow:
-          name: "Rainbow - Fast"
-          speed: 50
       - pulse:
           name: "Pulse"
           transition_length: 1s
@@ -105,9 +100,31 @@ light:
         from: 0
         to: 27
 
+  # Those lights are available based on the model selections
+  - &light_partition_with_effects
+    <<: *light_partition_with_effects_common
+    id: light_eu
+    name: Light EU
+    effects:
+      - addressable_rainbow:
+          name: "Rainbow"
+          width: 28
+      - addressable_rainbow:
+          name: "Rainbow - Fast"
+          width: 28
+          speed: 50
+
   - id: light_us
     name: Light US
-    <<: *light_partition_with_effects
+    <<: *light_partition_with_effects_common
+    effects:
+      - addressable_rainbow:
+          name: "Rainbow"
+          width: 32
+      - addressable_rainbow:
+          name: "Rainbow - Fast"
+          width: 32
+          speed: 50
     segments:
       - id: light_full
         from: 0

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
@@ -74,42 +74,34 @@ light:
           name: "Pulse"
           transition_length: 1s
           update_interval: 1s
-          width: 28
       - pulse:
           name: "Pulse - Slow"
           transition_length: 2s
           update_interval: 2s
-          width: 28
       - addressable_scan:
           name: "Scan"
           move_interval: 100ms
           scan_width: 3
-          width: 28
       - addressable_twinkle:
           name: "Twinkle"
           twinkle_probability: 5%
           progress_interval: 4ms
-          width: 28
       - addressable_random_twinkle:
           name: "Random Twinkle"
           twinkle_probability: 20%
           progress_interval: 32ms
-          width: 28
       - addressable_fireworks:
           name: "Fireworks"
           update_interval: 32ms
           spark_probability: 10%
           use_random_color: false
           fade_out_rate: 120
-          width: 28
       - addressable_flicker:
           name: "Flicker"
           update_interval: 16ms
           intensity: 5%
-          width: 28
       - random:
           name: "Random"
-          width: 28
     segments:
       - id: light_full
         from: 0
@@ -134,52 +126,47 @@ light:
           name: "Pulse"
           transition_length: 1s
           update_interval: 1s
-          width: 32
       - pulse:
           name: "Pulse - Slow"
           transition_length: 2s
           update_interval: 2s
-          width: 32
       - addressable_scan:
           name: "Scan"
           move_interval: 100ms
           scan_width: 3
-          width: 32
       - addressable_twinkle:
           name: "Twinkle"
           twinkle_probability: 5%
           progress_interval: 4ms
-          width: 32
       - addressable_random_twinkle:
           name: "Random Twinkle"
           twinkle_probability: 20%
           progress_interval: 32ms
-          width: 32
       - addressable_fireworks:
           name: "Fireworks"
           update_interval: 32ms
           spark_probability: 10%
           use_random_color: false
           fade_out_rate: 120
-          width: 32
       - addressable_flicker:
           name: "Flicker"
           update_interval: 16ms
           intensity: 5%
-          width: 32
       - random:
           name: "Random"
-          width: 32
     segments:
       - id: light_full
         from: 0
         to: 31
 
-  - &light_partition_with_effects_eu_disabled
+  - &light_partition_no_effects_disabled
     id: light_eu_bottom
     name: Light - Bottom EU
+    platform: partition
     disabled_by_default: true
-    <<: *light_partition_with_effects_eu
+    default_transition_length: ${default_transition_length}
+    restore_mode: ${LIGHT_SIDES_RESTORE_MODE}
+    internal: true
     segments:
       - id: light_full
         from: 6
@@ -187,7 +174,7 @@ light:
         reversed: true
   - id: light_eu_left
     name: Light - Left EU
-    <<: *light_partition_with_effects_eu_disabled
+    <<: *light_partition_no_effects_disabled
     segments:
       - id: light_full
         from: 13
@@ -195,7 +182,7 @@ light:
         reversed: true
   - id: light_eu_right
     name: Light - Right EU
-    <<: *light_partition_with_effects_eu_disabled
+    <<: *light_partition_no_effects_disabled
     segments:
       - id: light_full
         from: 27
@@ -207,7 +194,7 @@ light:
         reversed: false
   - id: light_eu_top
     name: Light - Top EU
-    <<: *light_partition_with_effects_eu_disabled
+    <<: *light_partition_no_effects_disabled
     segments:
       - id: light_full
         from: 20
@@ -215,17 +202,15 @@ light:
         reversed: false
   - id: light_us_bottom
     name: Light - Bottom US
-    <<: *light_partition_with_effects_eu_disabled
+    <<: *light_partition_no_effects_disabled
     segments:
       - id: light_full
         from: 9
         to: 14
         reversed: true
-  - &light_partition_with_effects_us_disabled
-    id: light_us_left
+  - id: light_us_left
     name: Light - Left US
-    disabled_by_default: true
-    <<: *light_partition_with_effects_us
+    <<: *light_partition_no_effects_disabled
     segments:
       - id: light_full
         from: 15
@@ -233,7 +218,7 @@ light:
         reversed: true
   - id: light_us_right
     name: Light - Right US
-    <<: *light_partition_with_effects_us_disabled
+    <<: *light_partition_no_effects_disabled
     segments:
       - id: light_full
         from: 31
@@ -245,7 +230,7 @@ light:
         reversed: false
   - id: light_us_top
     name: Light - Top US
-    <<: *light_partition_with_effects_us_disabled
+    <<: *light_partition_no_effects_disabled
     segments:
       - id: light_full
         from: 25

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml
@@ -54,69 +54,74 @@ light:
     type: GRB
     variant: WS2811
 
-  # Those lights contain common effects for both models
-  - &light_partition_with_effects_common
-    id: light_base
-    name: Light Base
+  # Those lights are available based on the model selections
+  - &light_partition_with_effects_eu
+    id: light_eu
+    name: Light EU
     platform: partition
     default_transition_length: ${default_transition_length}
     internal: true
     restore_mode: ${LIGHT_SIDES_RESTORE_MODE}
     effects:
+      - addressable_rainbow:
+          name: "Rainbow"
+          width: 28
+      - addressable_rainbow:
+          name: "Rainbow - Fast"
+          width: 28
+          speed: 50
       - pulse:
           name: "Pulse"
           transition_length: 1s
           update_interval: 1s
+          width: 28
       - pulse:
           name: "Pulse - Slow"
           transition_length: 2s
           update_interval: 2s
+          width: 28
       - addressable_scan:
           name: "Scan"
           move_interval: 100ms
           scan_width: 3
+          width: 28
       - addressable_twinkle:
           name: "Twinkle"
           twinkle_probability: 5%
           progress_interval: 4ms
+          width: 28
       - addressable_random_twinkle:
           name: "Random Twinkle"
           twinkle_probability: 20%
           progress_interval: 32ms
+          width: 28
       - addressable_fireworks:
           name: "Fireworks"
           update_interval: 32ms
           spark_probability: 10%
           use_random_color: false
           fade_out_rate: 120
+          width: 28
       - addressable_flicker:
           name: "Flicker"
           update_interval: 16ms
           intensity: 5%
+          width: 28
       - random:
           name: "Random"
+          width: 28
     segments:
       - id: light_full
         from: 0
         to: 27
 
-  # Those lights are available based on the model selections
-  - &light_partition_with_effects
-    <<: *light_partition_with_effects_common
-    id: light_eu
-    name: Light EU
-    effects:
-      - addressable_rainbow:
-          name: "Rainbow"
-          width: 28
-      - addressable_rainbow:
-          name: "Rainbow - Fast"
-          width: 28
-          speed: 50
-
-  - id: light_us
+  - &light_partition_with_effects_us
+    id: light_us
     name: Light US
-    <<: *light_partition_with_effects_common
+    platform: partition
+    default_transition_length: ${default_transition_length}
+    internal: true
+    restore_mode: ${LIGHT_SIDES_RESTORE_MODE}
     effects:
       - addressable_rainbow:
           name: "Rainbow"
@@ -125,16 +130,56 @@ light:
           name: "Rainbow - Fast"
           width: 32
           speed: 50
+      - pulse:
+          name: "Pulse"
+          transition_length: 1s
+          update_interval: 1s
+          width: 32
+      - pulse:
+          name: "Pulse - Slow"
+          transition_length: 2s
+          update_interval: 2s
+          width: 32
+      - addressable_scan:
+          name: "Scan"
+          move_interval: 100ms
+          scan_width: 3
+          width: 32
+      - addressable_twinkle:
+          name: "Twinkle"
+          twinkle_probability: 5%
+          progress_interval: 4ms
+          width: 32
+      - addressable_random_twinkle:
+          name: "Random Twinkle"
+          twinkle_probability: 20%
+          progress_interval: 32ms
+          width: 32
+      - addressable_fireworks:
+          name: "Fireworks"
+          update_interval: 32ms
+          spark_probability: 10%
+          use_random_color: false
+          fade_out_rate: 120
+          width: 32
+      - addressable_flicker:
+          name: "Flicker"
+          update_interval: 16ms
+          intensity: 5%
+          width: 32
+      - random:
+          name: "Random"
+          width: 32
     segments:
       - id: light_full
         from: 0
         to: 31
 
-  - &light_partition_with_effects_disabled
+  - &light_partition_with_effects_eu_disabled
     id: light_eu_bottom
     name: Light - Bottom EU
     disabled_by_default: true
-    <<: *light_partition_with_effects
+    <<: *light_partition_with_effects_eu
     segments:
       - id: light_full
         from: 6
@@ -142,7 +187,7 @@ light:
         reversed: true
   - id: light_eu_left
     name: Light - Left EU
-    <<: *light_partition_with_effects_disabled
+    <<: *light_partition_with_effects_eu_disabled
     segments:
       - id: light_full
         from: 13
@@ -150,7 +195,7 @@ light:
         reversed: true
   - id: light_eu_right
     name: Light - Right EU
-    <<: *light_partition_with_effects_disabled
+    <<: *light_partition_with_effects_eu_disabled
     segments:
       - id: light_full
         from: 27
@@ -162,7 +207,7 @@ light:
         reversed: false
   - id: light_eu_top
     name: Light - Top EU
-    <<: *light_partition_with_effects_disabled
+    <<: *light_partition_with_effects_eu_disabled
     segments:
       - id: light_full
         from: 20
@@ -170,15 +215,17 @@ light:
         reversed: false
   - id: light_us_bottom
     name: Light - Bottom US
-    <<: *light_partition_with_effects_disabled
+    <<: *light_partition_with_effects_eu_disabled
     segments:
       - id: light_full
         from: 9
         to: 14
         reversed: true
-  - id: light_us_left
+  - &light_partition_with_effects_us_disabled
+    id: light_us_left
     name: Light - Left US
-    <<: *light_partition_with_effects_disabled
+    disabled_by_default: true
+    <<: *light_partition_with_effects_us
     segments:
       - id: light_full
         from: 15
@@ -186,7 +233,7 @@ light:
         reversed: true
   - id: light_us_right
     name: Light - Right US
-    <<: *light_partition_with_effects_disabled
+    <<: *light_partition_with_effects_us_disabled
     segments:
       - id: light_full
         from: 31
@@ -198,7 +245,7 @@ light:
         reversed: false
   - id: light_us_top
     name: Light - Top US
-    <<: *light_partition_with_effects_disabled
+    <<: *light_partition_with_effects_us_disabled
     segments:
       - id: light_full
         from: 25


### PR DESCRIPTION
Previously this would loop incorrectly, on the top right corner of the US model the colors would switch abruptly. Setting the width to the number of LEDs seems to fix this issue and the rainbow effect now loops correctly.

Couldn't find a better way to merge effects in YAML, it seems that adding IDs to the effects causes errors and not adding IDs causes YAML to append the arrays, causing other errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved organization of lighting effects by clearly separating configurations for EU and US models, ensuring model-specific settings are explicitly defined for better clarity and customization.
  * Unified disabled light partitions under a single configuration for consistent behavior across models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->