### PR TITLE
Fix incorrect triggering of multitouch event when swiping

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_touch.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_touch.yaml
@@ -432,8 +432,6 @@ tx_ultimate_easy:
             {"swipe-direction", swipe_direction.c_str()},
             {"position", std::to_string(touch.x)}
           });
-          ESP_LOGI("core_hw_touch", "Multi-touch released");
-          touch_on_multi_touch_release->execute();
           ESP_LOGI("core_hw_touch", "Swipe %s", swipe_direction.c_str());
           touch_swipe_left->execute();
 


### PR DESCRIPTION
I saw that this slipped in during a refactor to support the latest ESPHome version (5ea4f2015b03a2443633b5ad216f2877f8c73437) . Previously, this code was not there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swipe left gesture handling by removing unnecessary multi-touch release actions and related log messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->