### PR TITLE
Fix: Relay mode substitution resolution failure (#163)

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_hw_relays.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_hw_relays.yaml
@@ -19,10 +19,15 @@ substitutions:
   relay_3_mode: switch  # 'switch', 'light', or 'disabled'
   relay_4_mode: switch  # 'switch', 'light', or 'disabled'
 
-  SL_RELAY_1_MODE: ${ 1 if relay_1_mode is string and relay_1_mode | lower == "switch" else (2 if relay_1_mode is string and relay_1_mode | lower == "light" else 0) }
-  SL_RELAY_2_MODE: ${ 1 if relay_2_mode is string and relay_2_mode | lower == "switch" else (2 if relay_2_mode is string and relay_2_mode | lower == "light" else 0) }
-  SL_RELAY_3_MODE: ${ 1 if relay_3_mode is string and relay_3_mode | lower == "switch" else (2 if relay_3_mode is string and relay_3_mode | lower == "light" else 0) }
-  SL_RELAY_4_MODE: ${ 1 if relay_4_mode is string and relay_4_mode | lower == "switch" else (2 if relay_4_mode is string and relay_4_mode | lower == "light" else 0) }
+  RELAY_1_MODE_LOWER: ${ relay_1_mode | lower }
+  RELAY_2_MODE_LOWER: ${ relay_2_mode | lower }
+  RELAY_3_MODE_LOWER: ${ relay_3_mode | lower }
+  RELAY_4_MODE_LOWER: ${ relay_4_mode | lower }
+
+  SL_RELAY_1_MODE: ${ 1 if RELAY_1_MODE_LOWER == "switch" else (2 if RELAY_1_MODE_LOWER == "light" else 0) }
+  SL_RELAY_2_MODE: ${ 1 if RELAY_2_MODE_LOWER == "switch" else (2 if RELAY_2_MODE_LOWER == "light" else 0) }
+  SL_RELAY_3_MODE: ${ 1 if RELAY_3_MODE_LOWER == "switch" else (2 if RELAY_3_MODE_LOWER == "light" else 0) }
+  SL_RELAY_4_MODE: ${ 1 if RELAY_4_MODE_LOWER == "switch" else (2 if RELAY_4_MODE_LOWER == "light" else 0) }
 
   RELAY_MODE_TEXT_SWITCH: "Switch"
   RELAY_MODE_TEXT_LIGHT: "Light"


### PR DESCRIPTION
ESPHome failed to correctly resolve the complex inline Jinja2 conditional expressions used in the  `relay_*_mode` and resolved to internal `SL_RELAY_*_MODE` substitutions, causing relay mode to always evaluate to `0` (disabled), regardless of the configured value. This broke all relay control after updating to `2026.3.1`.

This hot-fix splits the evaluation into two steps: intermediate `RELAY_*_MODE_LOWER` substitutions first normalize the input with `| lower`, allowing the subsequent `SL_RELAY_*_MODE` conditionals to use simpler, reliably-resolved expressions.

**Affected file:** `ESPHome/TX-Ultimate-Easy-ESPHome_hw_relays.yaml` **Fixes:** #163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal relay mode configuration logic for enhanced code maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->