### PR TITLE
Fix button and indicator LED reliability issues

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_hw_buttons.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_hw_buttons.yaml
@@ -310,7 +310,12 @@ script:
           } else if (id(button_press_position) != position) {
             // Position changed
             start_new_sequence = true;
-          } else if (id(last_release_time) > 0) {
+          } else if (id(last_release_time) == 0) {
+            // Previous press never received a release event (touch panel glitch)
+            // Treat as stale press and start a new sequence
+            ESP_LOGW("${TAG_HW_BUTTONS}", "Stale press detected (no release received), starting new sequence");
+            start_new_sequence = true;
+          } else {
             // Check if enough time has passed since last release (for inter-click gap)
             // Use runtime value from HA instead of compile-time constant
             uint32_t gap_window = (uint32_t) nr_button_multi_click_delay->state;

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_hw_relays.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_hw_relays.yaml
@@ -606,7 +606,7 @@ script:
                           "Invalid set with ${LIGHT_MODE_BOTTOM_OR_LEFT_TEXT} light for Relay %" PRIu8, light_index+1);
                 return;
               }
-              if (state and !id(gb_lights_1)[light_index]->current_values.is_on()) {
+              if (state) {
                 ESP_LOGI("${TAG_HW_RELAYS}",
                           "Turn-on ${LIGHT_MODE_BOTTOM_OR_LEFT_TEXT} light for Relay %" PRIu8, light_index+1);
                 auto call = id(gb_lights_1)[light_index]->turn_on();
@@ -615,7 +615,7 @@ script:
                 if (LIGHT_BRIGHTNESS_TURN_ON > 0 and LIGHT_BRIGHTNESS_TURN_ON <= 100)
                   call.set_brightness(LIGHT_BRIGHTNESS_TURN_ON / 100.0f);
                 call.perform();
-              } else if (!state and id(gb_lights_1)[light_index]->current_values.is_on()) {
+              } else {
                 ESP_LOGI("${TAG_HW_RELAYS}",
                           "Turn-off ${LIGHT_MODE_BOTTOM_OR_LEFT_TEXT} light for Relay %" PRIu8, light_index+1);
                 auto call = id(gb_lights_1)[light_index]->turn_off();
@@ -630,7 +630,7 @@ script:
                           "Invalid set with ${LIGHT_MODE_TOP_OR_RIGHT_TEXT} light for Relay %" PRIu8, light_index+1);
                 return;
               }
-              if (state and !id(gb_lights_2)[light_index]->current_values.is_on()) {
+              if (state) {
                 ESP_LOGI("${TAG_HW_RELAYS}",
                           "Turn-on ${LIGHT_MODE_TOP_OR_RIGHT_TEXT} light for Relay %" PRIu8, light_index+1);
                 auto call = id(gb_lights_2)[light_index]->turn_on();
@@ -639,7 +639,7 @@ script:
                 if (LIGHT_BRIGHTNESS_TURN_ON > 0 and LIGHT_BRIGHTNESS_TURN_ON <= 100)
                   call.set_brightness(LIGHT_BRIGHTNESS_TURN_ON / 100.0f);
                 call.perform();
-              } else if (!state and id(gb_lights_2)[light_index]->current_values.is_on()) {
+              } else {
                 ESP_LOGI("${TAG_HW_RELAYS}",
                           "Turn-off ${LIGHT_MODE_TOP_OR_RIGHT_TEXT} light for Relay %" PRIu8, light_index+1);
                 auto call = id(gb_lights_2)[light_index]->turn_off();


### PR DESCRIPTION
## Summary

Fixes two reliability bugs surfaced during rapid/edge-case button interactions:

- **False multi-click classification** when the touch panel fails to send a RELEASE event. The next press incorrectly incremented `click_counter` instead of starting a new sequence, causing `double_click`/`multiple_click` outputs that skipped the relay toggle.
- **Indicator LED desync during rapid relay toggling**. The `light_set_state` guard checked `current_values.is_on()`, which reflects the *interpolated* state mid-transition. Rapid toggles could see a stale value and skip the update, leaving the LED in the wrong state.

## Changes

- `ESPHome/TX-Ultimate-Easy-ESPHome_hw_buttons.yaml` — detect stale press (`button_press_start_time > 0` && `last_release_time == 0`) and force a new click sequence.
- `ESPHome/TX-Ultimate-Easy-ESPHome_hw_relays.yaml` — drop the `current_values.is_on()` guards so the indicator LED is always set to match the relay state. ESPHome handles redundant `turn_on`/`turn_off` calls gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed button press sequence detection to handle edge cases more robustly.

* **Refactor**
  * Streamlined light control logic for light groups with more direct state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->