### PR TITLE
dropping the core_ and standard_ prefix in the example advanced config file

### DIFF
--- a/TX-Ultimate-Easy-ESPHome_advanced.yaml
+++ b/TX-Ultimate-Easy-ESPHome_advanced.yaml
@@ -25,17 +25,17 @@ packages:
     refresh: 5min
     files:
       # Core (essential) packages - Do not disable these unless you know what you're doing
-      - ESPHome/TX-Ultimate-Easy-ESPHome_core_common.yaml              # Basic shared settings
-      - ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_buttons.yaml          # Button logic
-      - ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds.yaml             # LED configuration
-      - ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_leds_individual.yaml  # LED configuration
-      - ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_touch.yaml            # Touch panel support
+      - ESPHome/TX-Ultimate-Easy-ESPHome_common.yaml              # Basic shared settings
+      - ESPHome/TX-Ultimate-Easy-ESPHome_hw_buttons.yaml          # Button logic
+      - ESPHome/TX-Ultimate-Easy-ESPHome_hw_leds.yaml             # LED configuration
+      - ESPHome/TX-Ultimate-Easy-ESPHome_hw_leds_individual.yaml  # LED configuration
+      - ESPHome/TX-Ultimate-Easy-ESPHome_hw_touch.yaml            # Touch panel support
 
       # Optional functionality - Can be enabled/disabled as needed
-      - ESPHome/TX-Ultimate-Easy-ESPHome_standard_hw_relays.yaml       # Relay control
-      - ESPHome/TX-Ultimate-Easy-ESPHome_standard_hw_vibration.yaml    # Haptic feedback
+      - ESPHome/TX-Ultimate-Easy-ESPHome_hw_relays.yaml       # Relay control
+      - ESPHome/TX-Ultimate-Easy-ESPHome_hw_vibration.yaml    # Haptic feedback
 
       # Audio options (use none or choose only one - using both will fail)
-      - ESPHome/TX-Ultimate-Easy-ESPHome_standard_media_player.yaml    # Media player (Recommended for most users)
-      # - ESPHome/TX-Ultimate-Easy-ESPHome_standard_hw_speaker.yaml    # Basic speaker
+      - ESPHome/TX-Ultimate-Easy-ESPHome_media_player.yaml    # Media player (Recommended for most users)
+      # - ESPHome/TX-Ultimate-Easy-ESPHome_hw_speaker.yaml    # Basic speaker
 ...


### PR DESCRIPTION
following of a2bfa99 and 446d3ef

i simply made the changes that were made in readme.md from 446d3ef in the corresponding example config file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized component includes in template configuration to improve structure and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/edwardtfn/TX-Ultimate-Easy/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->