### PR TITLE
Fix boot-time relay deadlock that froze the device after a few toggles

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_hw_relays.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_hw_relays.yaml
@@ -346,8 +346,17 @@ script:
     then:
       - script.execute: boot_initialize_relays
 
+  - id: !extend boot_done
+    then:
+      # bs_boot_completed is ON at this point (set by the base boot_done), so the
+      # guard in show_relay_status no longer short-circuits. Repaint relay LEDs once
+      # to reflect the relay state that was restored (but deferred) during boot.
+      - script.execute: show_relay_status
+
   - id: boot_initialize_relays
-    mode: restart
+    # Runs once at boot (triggered by boot_initialize). "single" mode means stray
+    # re-triggers during boot are ignored instead of cancelling in-progress work.
+    mode: single
     then:
       - script.execute: boot_initialize_relays_group_assignments
       - script.execute: boot_initialize_relays_light_modes
@@ -360,6 +369,9 @@ script:
             - lambda: return id(boot_initialization_relays_group_assignments);
             - lambda: return id(boot_initialization_relays_light_modes);
             - lambda: return id(boot_initialization_relays_relay_modes);
+          # Bounded so the single-threaded loop is never blocked indefinitely.
+          timeout: 5s
+      # Always release downstream waiters, even if the wait_until above timed out.
       - globals.set:
           id: boot_initialization_relays
           value: 'true'
@@ -664,51 +676,62 @@ script:
   - id: show_relay_status
     mode: restart
     then:
-      - script.wait: boot_initialize_relays
-      - lambda: |-
-          if (not id(boot_initialization_relays)) {
-            ESP_LOGW("${TAG_HW_RELAYS}", "Relays not initialized yet");
-            if (not boot_initialize_relays->is_running())
-              boot_initialize_relays->execute();
-            return;
-          }
-          for (uint8_t i = 0; i < ${gang_count}; i++) {
-            bool relay_state = false;
-            std::string light_mode;
+      # Skip the visual LED sync during boot. Relay *state* restoration still happens
+      # via the switch handlers; only the LED painting is deferred until boot_done
+      # repaints it. A bare leading `lambda: return;` would NOT work here, since a
+      # return only exits the lambda and the script would fall through to the paint.
+      - if:
+          condition:
+            - binary_sensor.is_on: bs_boot_completed
+          then:
+            # Bounded wait for relay boot initialization. script.wait has no timeout,
+            # so wait_until is used as defense-in-depth against an indefinite block.
+            - wait_until:
+                condition:
+                  lambda: return id(boot_initialization_relays);
+                timeout: 10s
+            - lambda: |-
+                if (not id(boot_initialization_relays)) {
+                  ESP_LOGW("${TAG_HW_RELAYS}", "Relays not initialized yet");
+                  return;
+                }
+                for (uint8_t i = 0; i < ${gang_count}; i++) {
+                  bool relay_state = false;
+                  std::string light_mode;
 
-            // Determine relay state and light mode
-            switch (i) {
-              case 0:
-                relay_state = id(relay_1_state);
-                light_mode = sl_relay_1_light_mode->current_option();
-                break;
-              case 1:
-                relay_state = id(relay_2_state);
-                light_mode = sl_relay_2_light_mode->current_option();
-                break;
-              case 2:
-                relay_state = id(relay_3_state);
-                light_mode = sl_relay_3_light_mode->current_option();
-                break;
-              case 3:
-                relay_state = id(relay_4_state);
-                light_mode = sl_relay_4_light_mode->current_option();
-                break;
-            }
+                  // Determine relay state and light mode
+                  switch (i) {
+                    case 0:
+                      relay_state = id(relay_1_state);
+                      light_mode = sl_relay_1_light_mode->current_option();
+                      break;
+                    case 1:
+                      relay_state = id(relay_2_state);
+                      light_mode = sl_relay_2_light_mode->current_option();
+                      break;
+                    case 2:
+                      relay_state = id(relay_3_state);
+                      light_mode = sl_relay_3_light_mode->current_option();
+                      break;
+                    case 3:
+                      relay_state = id(relay_4_state);
+                      light_mode = sl_relay_4_light_mode->current_option();
+                      break;
+                  }
 
-            ESP_LOGV("${TAG_HW_RELAYS}", "Relay %" PRIu8 " is %s", i + 1, relay_state ? "ON" : "OFF");
-            ESP_LOGV("${TAG_HW_RELAYS}", "Light Mode for Relay %" PRIu8 ": %s", i + 1, light_mode.c_str());
+                  ESP_LOGV("${TAG_HW_RELAYS}", "Relay %" PRIu8 " is %s", i + 1, relay_state ? "ON" : "OFF");
+                  ESP_LOGV("${TAG_HW_RELAYS}", "Light Mode for Relay %" PRIu8 ": %s", i + 1, light_mode.c_str());
 
-            // Use light_set_state for light updates
-            if (light_mode != "${LIGHT_MODE_DISABLED_TEXT}") {
-              if (light_mode == "${LIGHT_MODE_BOTTOM_OR_LEFT_TEXT}" || light_mode == "${LIGHT_MODE_BOTH_TEXT}") {
-                light_set_state->execute(1, i, relay_state);  // Left/bottom light
-              }
-              if (light_mode == "${LIGHT_MODE_TOP_OR_RIGHT_TEXT}" || light_mode == "${LIGHT_MODE_BOTH_TEXT}") {
-                light_set_state->execute(2, i, relay_state);  // Right/top light
-              }
-            }
-          }
+                  // Use light_set_state for light updates
+                  if (light_mode != "${LIGHT_MODE_DISABLED_TEXT}") {
+                    if (light_mode == "${LIGHT_MODE_BOTTOM_OR_LEFT_TEXT}" || light_mode == "${LIGHT_MODE_BOTH_TEXT}") {
+                      light_set_state->execute(1, i, relay_state);  // Left/bottom light
+                    }
+                    if (light_mode == "${LIGHT_MODE_TOP_OR_RIGHT_TEXT}" || light_mode == "${LIGHT_MODE_BOTH_TEXT}") {
+                      light_set_state->execute(2, i, relay_state);  // Right/top light
+                    }
+                  }
+                }
 
 select:
   - &relay_light_mode

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_night_mode.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_night_mode.yaml
@@ -107,7 +107,12 @@ script:
   # Waits for relay boot initialization so it is safe to call from on_boot.
   - id: night_mode_apply
     then:
-      - script.wait: boot_initialize_relays
+      # Bounded wait for relay boot initialization. script.wait has no timeout, so
+      # wait_until is used as defense-in-depth against an indefinite block on boot.
+      - wait_until:
+          condition:
+            lambda: return id(boot_initialization_relays);
+          timeout: 10s
       # Re-check the flag: night mode may have been disabled while we were waiting.
       - if:
           condition:


### PR DESCRIPTION
This release fixes a boot-time deadlock in relay initialization that could freeze the device after a few relay toggles. Affected devices stopped responding until a restart, and "Boot completed" stayed NO on every boot.

Fixes #172.

### What changed
- The device no longer freezes after toggling relays.
- The persistent "Boot completed: NO" is resolved; boot now completes normally.
- Relay LEDs are repainted once boot finishes, so they correctly reflect the restored relay state.

### Technical details
- Removed a self-reinforcing restart loop where `show_relay_status` re-triggered `boot_initialize_relays`, which kept cancelling its own in-progress work.
- `boot_initialize_relays` now runs in `single` mode with a time-bounded wait, so it always completes and releases downstream waiters.
- All waits on relay boot initialization (`show_relay_status`, `night_mode_apply`) are now bounded, so the single-threaded loop can never block indefinitely.
- Early relay toggles during boot no longer enter the LED feedback/wait chain; the visual sync is deferred and applied once boot completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay and status light startup behavior so indicators now sync more reliably after boot.
  * Added time limits to startup waits to prevent the system from hanging during initialization.
  * Night mode now waits safely for relay setup to finish before applying saved lighting settings.

* **Chores**
  * Updated boot sequencing to better coordinate relay initialization and post-boot status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->