### PR TITLE
Turning Night Mode off now clears all LEDs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v11
         with:
           # ---------------------------------------------------------------
           # Issue configuration

--- a/.github/workflows/validate_clang_format.yml
+++ b/.github/workflows/validate_clang_format.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - uses: RafikFarhad/clang-format-github-action@v3
+      - uses: RafikFarhad/clang-format-github-action@v7
         with:
           sources: "components/tx_ultimate_easy/*.h,components/tx_ultimate_easy/*.cpp"
 ...

--- a/.github/workflows/validate_markdown.yml
+++ b/.github/workflows/validate_markdown.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Ensures full commit history for diff
 
@@ -35,7 +35,7 @@ jobs:
           fi
 
       - name: Markdown Lint
-        uses: DavidAnson/markdownlint-cli2-action@v14
+        uses: DavidAnson/markdownlint-cli2-action@v24
         if: env.any_changed == 'true'
         with:
           globs: ${{ env.changed_files }}
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/validate_yamllint.yml
+++ b/.github/workflows/validate_yamllint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Ensures full commit history for diff
 

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -44,7 +44,7 @@ jobs:
       - name: Get PR information
         id: pr_info
         if: github.event_name == 'push'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             try {

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_night_mode.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_night_mode.yaml
@@ -14,6 +14,8 @@
 substitutions:
   night_mode_light_transition_length: 500ms
   night_mode_sync_leds_delay: 20ms
+  # Safety bound for the fade-out wait; must be longer than the transition itself.
+  night_mode_light_off_timeout: 2s
 
 esphome:
   build_flags:
@@ -173,11 +175,21 @@ switch:
             night_mode_apply->execute();
     on_turn_off:
       then:
-        - lambda: |-
-            // No need to clear the snapshot values - they will be overwritten next time night mode is enabled.
-            night_mode_apply->stop();  // stop in case we're in the middle of a transition
-            light_night_mode_leds->turn_off();
-            show_relay_status->execute();  // re-evaluate all relay indicators
+        # Stop the apply script in case we are in the middle of a transition.
+        # The snapshot globals are intentionally left untouched - they are
+        # overwritten the next time night mode is enabled.
+        - script.stop: night_mode_apply
+        - light.turn_off:
+            id: light_night_mode_leds
+            transition_length: ${night_mode_light_transition_length}
+        # The night mode partition spans the whole strip and keeps writing to it
+        # until the fade-out completes, so an earlier repaint would be overwritten.
+        # The timeout is defense-in-depth only: it should never be reached.
+        - wait_until:
+            condition:
+              - light.is_off: light_night_mode_leds
+            timeout: ${night_mode_light_off_timeout}
+        - script.execute: show_relay_status  # re-evaluate all relay indicators
 
   # ── Settings (entity_category: config → grouped under "Configuration") ────
   - id: sw_night_mode_suppress_vibration


### PR DESCRIPTION
Disabling Night Mode only repainted the four relay indicators, leaving the rest of the ring lit at the Night Mode color until something else updated it.

The LEDs now fade out when Night Mode is disabled, and the relay indicators are restored once the fade completes.

Thanks to Elkropac for reporting and testing.

Fixes https://github.com/edwardtfn/TX-Ultimate-Easy/issues/177#issuecomment-5251576984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added a configurable 2-second timeout for Night Mode LED fade-out.
  * Disabling Night Mode now smoothly fades out the LEDs before refreshing relay indicators.
  * Active Night Mode operations are stopped when the mode is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->