### PR TITLE
Add default transition length to night mode configuration

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_night_mode.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_night_mode.yaml
@@ -16,6 +16,7 @@ substitutions:
   night_mode_sync_leds_delay: 20ms
   # Safety bound for the fade-out wait; must be longer than the transition itself.
   night_mode_light_off_timeout: 2s
+  night_mode_light_default_transition_length: 0s
 
 esphome:
   build_flags:
@@ -90,7 +91,7 @@ light:
     blue: out_night_mode_blue
     icon: mdi:weather-night
     restore_mode: RESTORE_DEFAULT_OFF
-    default_transition_length: 0s
+    default_transition_length: ${night_mode_light_default_transition_length}
 
   # Internal partition that drives the physical strip while Night Mode is active.
   - id: light_night_mode_leds

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_night_mode.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_night_mode.yaml
@@ -90,6 +90,7 @@ light:
     blue: out_night_mode_blue
     icon: mdi:weather-night
     restore_mode: RESTORE_DEFAULT_OFF
+    default_transition_length: 0s
 
   # Internal partition that drives the physical strip while Night Mode is active.
   - id: light_night_mode_leds


### PR DESCRIPTION
Currently default transition time is 1 second, thus triggering up to 30+ night_mode_sync_leds calls, depending how distant new color is from previous one. IMHO no practical need in transition in color picker. Setting transition time to 0 sec lead to no more 3 sync calls on every color change on picker.

## Summary by Sourcery

Enhancements:
- Configure the night mode light to default to a zero-second transition duration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Night mode lighting now switches colors instantly by default, without a transition delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->