### PR TITLE
Restore LEDs after Lights (all) turned off

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_hw_leds.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_hw_leds.yaml
@@ -147,6 +147,15 @@ light:
       - id: light_full
         from: 0
         to: ${LIGHT_MAX_ADDR}
+    on_turn_off:
+      then:
+        - lambda: |-
+            #ifdef TX_ULTIMATE_EASY_NIGHT_MODE
+            if (sw_night_mode->state) { night_mode_apply->execute(); }
+            #endif
+            #ifdef TX_ULTIMATE_EASY_HW_RELAYS
+            show_relay_status->execute();
+            #endif
 
   - id: light_bottom
     name: Light - Bottom


### PR DESCRIPTION
Currently turning off Lights (all) lead to all LEDs turned off. Adding on_turn_off will ensure to restore night mode & relay LEDs.

## Summary by Sourcery

Enhancements:
- Add on_turn_off handler to the main light group to reapply night mode and relay LED status after all lights are switched off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic night mode restoration when the light is turned off, when enabled.
  * Added an optional relay-status display after the light turns off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->