### PR TITLE
feat: Restore Night Mode LEDs

### DIFF
--- a/.github/workflows/validate_clang_format.yml
+++ b/.github/workflows/validate_clang_format.yml
@@ -19,8 +19,8 @@ jobs:
   clang-format-checking:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - uses: RafikFarhad/clang-format-github-action@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: RafikFarhad/clang-format-github-action@601dce42932921470d1acf9295faa87752162048  # v7
         with:
           sources: "components/tx_ultimate_easy/*.h,components/tx_ultimate_easy/*.cpp"
 ...

--- a/.github/workflows/validate_markdown.yml
+++ b/.github/workflows/validate_markdown.yml
@@ -35,7 +35,7 @@ jobs:
           fi
 
       - name: Markdown Lint
-        uses: DavidAnson/markdownlint-cli2-action@v24
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff  # v24.2.0
         if: env.any_changed == 'true'
         with:
           globs: ${{ env.changed_files }}
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
 
@@ -66,7 +66,7 @@ jobs:
           fi
 
       - name: Markdown links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368  # v1
         if: env.any_changed == 'true'
         with:
           check-modified-files-only: yes

--- a/.github/workflows/validate_markdown.yml
+++ b/.github/workflows/validate_markdown.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0  # Ensures full commit history for diff
 

--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -17,13 +17,13 @@ jobs:
     name: Lint
     steps:
       - name: Check out source repository
-        uses: actions/checkout@main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Set up Python environment
-        uses: actions/setup-python@main
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.11"
       - name: flake8 Lint
-        uses: py-actions/flake8@v2
+        uses: py-actions/flake8@84ec6726560b6d5bd68f2a5bed83d62b52bb50ba  # v2.3.0
         with:
           max-line-length: "200"
           path: "components/tx_ultimate_easy"

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_hw_leds.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_hw_leds.yaml
@@ -147,6 +147,15 @@ light:
       - id: light_full
         from: 0
         to: ${LIGHT_MAX_ADDR}
+    on_turn_off:
+      then:
+        - lambda: |-
+            #ifdef TX_ULTIMATE_EASY_NIGHT_MODE
+            if (sw_night_mode->state) { night_mode_apply->execute(); }
+            #endif
+            #ifdef TX_ULTIMATE_EASY_HW_RELAYS
+            show_relay_status->execute();
+            #endif
 
   - id: light_bottom
     name: Light - Bottom

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_night_mode.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_night_mode.yaml
@@ -16,6 +16,7 @@ substitutions:
   night_mode_sync_leds_delay: 20ms
   # Safety bound for the fade-out wait; must be longer than the transition itself.
   night_mode_light_off_timeout: 2s
+  night_mode_light_default_transition_length: 0s
 
 esphome:
   build_flags:
@@ -90,7 +91,7 @@ light:
     blue: out_night_mode_blue
     icon: mdi:weather-night
     restore_mode: RESTORE_DEFAULT_OFF
-    default_transition_length: 0s
+    default_transition_length: ${night_mode_light_default_transition_length}
 
   # Internal partition that drives the physical strip while Night Mode is active.
   - id: light_night_mode_leds

--- a/ESPHome/TX-Ultimate-Easy-ESPHome_night_mode.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_night_mode.yaml
@@ -90,6 +90,7 @@ light:
     blue: out_night_mode_blue
     icon: mdi:weather-night
     restore_mode: RESTORE_DEFAULT_OFF
+    default_transition_length: 0s
 
   # Internal partition that drives the physical strip while Night Mode is active.
   - id: light_night_mode_leds


### PR DESCRIPTION
## Summary by Sourcery

Align ESPHome night mode behavior and pin GitHub Actions to specific versions/commits for reproducible CI.

New Features:
- Trigger night mode and relay status updates when the main LED strip light is turned off.
- Introduce a configurable default transition length for the night mode light.

CI:
- Pin checkout, markdown validation, Python linting, and clang-format GitHub Actions to explicit commit SHAs for more deterministic workflows.