### PR TITLE
Fix swipe positions

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_hw_touch.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_hw_touch.yaml
@@ -375,7 +375,6 @@ tx_ultimate_easy:
       - lambda: |-
           esphome::tx_ultimate_easy::fire_ha_event("touch", "multi_touch", {
             {"action", "release"},
-            {"position", std::to_string(touch.x)}
           });
           ESP_LOGI("${TAG_HW_TOUCH}", "Multi-touch released");
           touch_on_multi_touch_release->execute();
@@ -403,7 +402,10 @@ tx_ultimate_easy:
           esphome::tx_ultimate_easy::fire_ha_event("touch", "swipe", {
             {"action", "${ID_SWIPE_LEFT_OR_UP_TEXT}"},
             {"swipe-direction", "${ID_SWIPE_LEFT_OR_UP_TEXT}"},
-            {"position", std::to_string(touch.x)}
+            {"swipe-from", std::to_string(touch.swipe_from)},
+            {"swipe-to", std::to_string(touch.swipe_to)},
+            {"swipe-from-button", std::to_string(touch.swipe_from_button)},
+            {"swipe-to-button", std::to_string(touch.swipe_to_button)}
           });
           ESP_LOGI("${TAG_HW_TOUCH}", "Swipe ${ID_SWIPE_LEFT_OR_UP_TEXT}");
           touch_swipe_${ID_SWIPE_LEFT_OR_UP_TEXT}->execute();
@@ -414,7 +416,10 @@ tx_ultimate_easy:
           esphome::tx_ultimate_easy::fire_ha_event("touch", "swipe", {
             {"action", "${ID_SWIPE_RIGHT_OR_DOWN_TEXT}"},
             {"swipe-direction", "${ID_SWIPE_RIGHT_OR_DOWN_TEXT}"},
-            {"position", std::to_string(touch.x)}
+            {"swipe-from", std::to_string(touch.swipe_from)},
+            {"swipe-to", std::to_string(touch.swipe_to)},
+            {"swipe-from-button", std::to_string(touch.swipe_from_button)},
+            {"swipe-to-button", std::to_string(touch.swipe_to_button)}
           });
           ESP_LOGI("${TAG_HW_TOUCH}", "Swipe ${ID_SWIPE_RIGHT_OR_DOWN_TEXT}");
           touch_swipe_${ID_SWIPE_RIGHT_OR_DOWN_TEXT}->execute();

--- a/components/tx_ultimate_easy/tx_ultimate_easy_touch.cpp
+++ b/components/tx_ultimate_easy/tx_ultimate_easy_touch.cpp
@@ -84,7 +84,7 @@ namespace esphome {
             // Calculate button width (rounds up to ensure full coverage)
             const uint8_t width =
                 (TOUCH_MAX_POSITION + TX_ULTIMATE_EASY_GANG_COUNT) / TX_ULTIMATE_EASY_GANG_COUNT;  // Width of each button region
-            if (width < 1)  // Invalid width - and prevents division by zero 
+            if (width < 1)  // Invalid width - and prevents division by zero
                 return 0;
             const uint8_t button = std::min(
                 static_cast<uint8_t>((position / width) + 1),      // Convert position to button index
@@ -113,16 +113,23 @@ namespace esphome {
                     break;
 
                 case TOUCH_STATE_SWIPE_LEFT:
-                    ESP_LOGV(TAG, "Swipe - Left (x=%d)", tp.x);
+                    ESP_LOGV(TAG, "Swipe - Left (from=%d, to=%d, from_button=%d, to_button=%d)",
+                             tp.swipe_from, tp.swipe_to, tp.swipe_from_button, tp.swipe_to_button);
                     this->trigger_swipe_left_.trigger(tp);
                     break;
 
                 case TOUCH_STATE_SWIPE_RIGHT:
-                    ESP_LOGV(TAG, "Swipe - Right (x=%d)", tp.x);
+                    ESP_LOGV(TAG, "Swipe - Right (from=%d, to=%d, from_button=%d, to_button=%d)",
+                             tp.swipe_from, tp.swipe_to, tp.swipe_from_button, tp.swipe_to_button);
                     this->trigger_swipe_right_.trigger(tp);
                     break;
 
                 case TOUCH_STATE_MULTI_TOUCH:
+                    // NOTE: uart_received_bytes[5] for a multi-touch event is a fixed
+                    // sentinel (0x0B), not a position. The hardware protocol does not
+                    // report which buttons participated in a multi-touch gesture, so
+                    // tp.x/tp.button are intentionally left invalid (see
+                    // get_touch_position_x()). Do not rely on tp.button here.
                     ESP_LOGV(TAG, "Multi touch - Released");
                     this->trigger_multi_touch_release_.trigger(tp);
                     break;
@@ -133,9 +140,9 @@ namespace esphome {
         }
 
         bool TxUltimateEasy::is_valid_data(const std::array<int, UART_RECEIVED_BYTES_SIZE> &uart_received_bytes) {
-            if (uart_received_bytes[0] != HEADER_BYTE_1 || 
-                uart_received_bytes[1] != HEADER_BYTE_2 || 
-                uart_received_bytes[2] != VALID_DATA_BYTE_2 || 
+            if (uart_received_bytes[0] != HEADER_BYTE_1 ||
+                uart_received_bytes[1] != HEADER_BYTE_2 ||
+                uart_received_bytes[2] != VALID_DATA_BYTE_2 ||
                 uart_received_bytes[3] != VALID_DATA_BYTE_3) {
                 return false;
             }
@@ -150,41 +157,60 @@ namespace esphome {
                     (uart_received_bytes[6] >= 0 || state == TOUCH_STATE_MULTI_TOUCH);
         }
 
+        /**
+         * @brief Decodes the lowest and highest touched channel from a swipe bitmap.
+         *
+         * uart_received_bytes[6] and uart_received_bytes[7] together form a 10-bit
+         * bitmap of channels crossed during the swipe gesture:
+         *   - uart_received_bytes[7] bits 0-7 represent channels 1-8
+         *   - uart_received_bytes[6] bits 0-1 represent channels 9-10
+         * (Confirmed both by the pre-existing implementation's comments and by
+         * community findings on the blakadder/tx-ultimate Berry driver.)
+         *
+         * @param uart_received_bytes Raw frame bytes.
+         * @param lowest_channel  Output: lowest channel number with its bit set (0 if none).
+         * @param highest_channel Output: highest channel number with its bit set (0 if none).
+         */
+        void TxUltimateEasy::get_swipe_range(const std::array<int, UART_RECEIVED_BYTES_SIZE> &uart_received_bytes,
+                                              uint8_t &lowest_channel, uint8_t &highest_channel) {
+            lowest_channel = 0;
+            highest_channel = 0;
+            const uint16_t crossed = (static_cast<uint16_t>(uart_received_bytes[6]) << 8) |
+                                      static_cast<uint16_t>(uart_received_bytes[7]);
+            for (uint8_t ch = 1; ch <= TOUCH_MAX_POSITION; ch++) {
+                if (crossed & (1 << (ch - 1))) {
+                    if (lowest_channel == 0) lowest_channel = ch;
+                    highest_channel = ch;
+                }
+            }
+        }
+
         int TxUltimateEasy::get_touch_position_x(const std::array<int, UART_RECEIVED_BYTES_SIZE> &uart_received_bytes) {
             switch (uart_received_bytes[4]) {
                 case TOUCH_STATE_RELEASE:
-                case TOUCH_STATE_MULTI_TOUCH:
                     return uart_received_bytes[5];
 
+                case TOUCH_STATE_MULTI_TOUCH:
+                    // uart_received_bytes[5] is a fixed sentinel value (0x0B) that only
+                    // marks "this is a multi-touch event". It is NOT a touch position,
+                    // unlike TOUCH_STATE_RELEASE. The hardware provides no per-button
+                    // information for multi-touch, so there is no valid position to
+                    // report here. Returning -1 correctly prevents get_touch_point()
+                    // from computing a bogus tp.button value from the sentinel byte.
+                    return -1;
+
                 case TOUCH_STATE_SWIPE_LEFT:
-                case TOUCH_STATE_SWIPE_RIGHT:
-                    // uart_received_bytes[5] indicates swipe direction:
-                    // 12 = find last touch position (scan right to left)
-                    // 13 = find first touch position (scan left to right)
-                    // Bytes 6-7 contain a 10-bit bitmap of touch positions:
-                    // Byte 7: bits 0-7 represent positions 1-8
-                    // Byte 6: bits 0-1 represent positions 9-10
-                    switch (uart_received_bytes[5]) {
-                        case 12:
-                            for (uint8_t i = 10; i > 0; i--) {
-                                if (i > 8
-                                    ? uart_received_bytes[6] & (1 << (i - 9))
-                                    : uart_received_bytes[7] & (1 << (i - 1))) {
-                                    return i;
-                                }
-                            }
-                            break;
-                        case 13:
-                            for (uint8_t i = 1; i <= 10; i++) {
-                                if (i > 8
-                                    ? uart_received_bytes[6] & (1 << (i - 9))
-                                    : uart_received_bytes[7] & (1 << (i - 1))) {
-                                    return i;
-                                }
-                            }
-                            break;
-                    }
-                    return uart_received_bytes[5];
+                case TOUCH_STATE_SWIPE_RIGHT: {
+                    // Bytes 6-7 form a 10-bit bitmap of crossed channels (see
+                    // get_swipe_range()). Kept for backward compatibility with
+                    // existing consumers of tp.x: returns the highest crossed
+                    // channel for a rightward swipe, or the lowest for a
+                    // leftward swipe -- the same single endpoint the original
+                    // implementation returned.
+                    uint8_t lowest = 0, highest = 0;
+                    this->get_swipe_range(uart_received_bytes, lowest, highest);
+                    return (uart_received_bytes[5] == TOUCH_STATE_SWIPE_RIGHT) ? highest : lowest;
+                }
 
                 default:
                     return uart_received_bytes[6];
@@ -198,7 +224,7 @@ namespace esphome {
             if (state == TOUCH_STATE_RELEASE && uart_received_bytes[5] == TOUCH_STATE_MULTI_TOUCH)
                 state = TOUCH_STATE_MULTI_TOUCH;
             if (state == TOUCH_STATE_SWIPE) {
-                state = (uart_received_bytes[5] == TOUCH_STATE_SWIPE_RIGHT) ? TOUCH_STATE_SWIPE_RIGHT : 
+                state = (uart_received_bytes[5] == TOUCH_STATE_SWIPE_RIGHT) ? TOUCH_STATE_SWIPE_RIGHT :
                         (uart_received_bytes[5] == TOUCH_STATE_SWIPE_LEFT) ? TOUCH_STATE_SWIPE_LEFT : state;
             }
             return state;
@@ -210,6 +236,21 @@ namespace esphome {
             if (tp.x >= 0)
                 tp.button = this->get_button_from_position(static_cast<uint8_t>(tp.x));
             tp.state = this->get_touch_state(uart_received_bytes);
+
+            if (tp.state == TOUCH_STATE_SWIPE_LEFT || tp.state == TOUCH_STATE_SWIPE_RIGHT) {
+                uint8_t lowest = 0, highest = 0;
+                this->get_swipe_range(uart_received_bytes, lowest, highest);
+                if (tp.state == TOUCH_STATE_SWIPE_RIGHT) {
+                    tp.swipe_from = lowest;
+                    tp.swipe_to = highest;
+                } else {  // TOUCH_STATE_SWIPE_LEFT
+                    tp.swipe_from = highest;
+                    tp.swipe_to = lowest;
+                }
+                tp.swipe_from_button = this->get_button_from_position(tp.swipe_from);
+                tp.swipe_to_button = this->get_button_from_position(tp.swipe_to);
+            }
+
             switch (tp.state) {
                 case TOUCH_STATE_RELEASE:
                     tp.state_str = "RELEASE";

--- a/components/tx_ultimate_easy/tx_ultimate_easy_touch.h
+++ b/components/tx_ultimate_easy/tx_ultimate_easy_touch.h
@@ -38,6 +38,14 @@ namespace esphome {
             int8_t x = -1;
             int8_t state = -1;
             std::string state_str = "Unknown";
+            // Populated only for TOUCH_STATE_SWIPE_LEFT / TOUCH_STATE_SWIPE_RIGHT.
+            // Decoded from the 10-bit crossed-channel bitmap in the raw frame
+            // (see get_swipe_range()); direction-aware start/end channel and
+            // their mapped button indices.
+            uint8_t swipe_from = 0;
+            uint8_t swipe_to = 0;
+            uint8_t swipe_from_button = 0;
+            uint8_t swipe_to_button = 0;
         };
 
         class TxUltimateEasy : public uart::UARTDevice, public Component {
@@ -155,6 +163,16 @@ namespace esphome {
              * @returns Numeric touch state code corresponding to the TOUCH_STATE_* constants, or -1 if not present/valid.
              */
             int get_touch_state(const std::array<int, UART_RECEIVED_BYTES_SIZE> &bytes);
+
+            /**
+             * Decode the lowest and highest touched channel from a swipe gesture's
+             * 10-bit crossed-channel bitmap (bytes 6-7 of the raw frame).
+             * @param bytes Array containing the raw received bytes.
+             * @param lowest_channel  Output: lowest channel number with its bit set (0 if none).
+             * @param highest_channel Output: highest channel number with its bit set (0 if none).
+             */
+            void get_swipe_range(const std::array<int, UART_RECEIVED_BYTES_SIZE> &bytes,
+                                  uint8_t &lowest_channel, uint8_t &highest_channel);
 
             Trigger<TouchPoint> trigger_touch_event_;
             Trigger<TouchPoint> trigger_touch_;


### PR DESCRIPTION
I tried to get out the swipe positions, and found the following ticket: https://github.com/blakadder/tx-ultimate/issues/7

Tested on 2 Gang EU TX Ultimate.
Feel free to adopt it.

<img width="1076" height="428" alt="image" src="https://github.com/user-attachments/assets/622af63e-39a4-410b-a69c-655b03e3fde2" />
<img width="1130" height="425" alt="image" src="https://github.com/user-attachments/assets/beb7b76e-0c0d-4a23-815f-536441441cb3" />

## Summary by Sourcery

Report accurate swipe endpoints and button positions while treating multi-touch events as positionless.

New Features:
- Expose direction-aware swipe start and end positions and their corresponding button indices in touch events.

Bug Fixes:
- Correct swipe position reporting by decoding the full crossed-channel range instead of relying on a single position value.
- Stop reporting the multi-touch marker byte as a touch position.

Enhancements:
- Expand swipe diagnostics to include source and destination channel and button information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved swipe gesture detection and reporting.
  * Swipe events now include starting and ending positions and their associated button indices.
  * Multi-touch release events no longer report a single position.
  * Multi-touch input is now clearly distinguished from single-touch positions.

* **Bug Fixes**
  * Improved accuracy when decoding swipe ranges from touch input data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->